### PR TITLE
Fix configuration for Loki hosted on Grafana Cloud

### DIFF
--- a/docs/docus/docs/configuration.md
+++ b/docs/docus/docs/configuration.md
@@ -207,7 +207,7 @@ We will need to specify the credentials and increase the request timeout to 15s.
 ```xml
 <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
     <http>
-        <url>https://logs-prod-us-central1.grafana.net/loki/api/v1</url>
+        <url>https://logs-prod-us-central1.grafana.net/loki/api/v1/push</url>
         <auth>
             <username>example_username</username>
             <password>example_api_token</password>


### PR DESCRIPTION
I was settings up my appender for Loki hosted on Grafana Cloud, and the URL mentioned in the docs seems invalid, I got:
```
Loki responded with non-success status 404 on Batch [...]
```

Adding `/push` fixed it.