### PR TITLE
Handling exceptions in writeBatch()

### DIFF
--- a/common/src/main/java/com/github/loki4j/common/JsonWriter.java
+++ b/common/src/main/java/com/github/loki4j/common/JsonWriter.java
@@ -41,6 +41,10 @@ public final class JsonWriter implements Writer {
         return raw.toByteArray();
     }
 
+    public final void reset() {
+        raw.reset();
+    }
+
     private void beginStreams(LogRecord firstRecord, String[] firstLabels) {
         raw.writeByte(OBJECT_START);
         raw.writeAsciiString("streams");

--- a/common/src/main/java/com/github/loki4j/common/ProtobufWriter.java
+++ b/common/src/main/java/com/github/loki4j/common/ProtobufWriter.java
@@ -113,7 +113,7 @@ public final class ProtobufWriter implements Writer {
     /**
      * Resets the writer
      */
-    private final void reset() {
+    public final void reset() {
         this.request = PushRequest.newBuilder();
         stream = null;
         size = 0;

--- a/common/src/main/java/com/github/loki4j/common/Writer.java
+++ b/common/src/main/java/com/github/loki4j/common/Writer.java
@@ -8,7 +8,13 @@ public interface Writer {
 
     int size();
 
+    default boolean isEmpty() {
+        return size() == 0;
+    }
+
     void toByteBuffer(ByteBuffer buffer);
 
     byte[] toByteArray();
+
+    void reset();
 }

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
@@ -162,6 +162,10 @@ public class Generators {
                 b.get(r);
                 return r;
             }
+            @Override
+            public void reset() {
+                b.clear();
+            }
         };
     }
 


### PR DESCRIPTION
In rare cases serializing a batch may fail causing all logging pipeline to break. This PR handles such errors.

Refs #97 