### PR TITLE
Make Java 8 gradle tasks optional

### DIFF
--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -38,9 +38,9 @@ jobs:
           architecture: x64
           targets: 'JDK_11'
       - name: Compile on Java 11
-        run: JAVA_HOME="${JDK_11}" ./gradlew check compileJava8TestJava
+        run: JAVA_HOME="${JDK_11}" ./gradlew -Pjava8 check compileJava8TestJava
       - name: Test on Java 8
-        run: JAVA_HOME="${JDK_8}" ./gradlew --info java8Test -x compileJava8TestJava -x compileJava8Java
+        run: JAVA_HOME="${JDK_8}" ./gradlew -Pjava8 --info java8Test -x compileJava8TestJava -x compileJava8Java
 
   java8-windows-tests:
     runs-on: windows-latest
@@ -59,6 +59,6 @@ jobs:
           architecture: x64
           targets: 'JDK_11'
       - name: Compile on Java 11
-        run: ./gradlew.bat "-Dorg.gradle.java.home=$env:JDK_11" check compileJava8TestJava
+        run: ./gradlew.bat "-Dorg.gradle.java.home=$env:JDK_11" -Pjava8 check compileJava8TestJava
       - name: Test on Java 8
-        run: ./gradlew.bat "-Dorg.gradle.java.home=$env:JDK_8" --info java8Test -x compileJava8TestJava -x compileJava8Java
+        run: ./gradlew.bat "-Dorg.gradle.java.home=$env:JDK_8" -Pjava8 --info java8Test -x compileJava8TestJava -x compileJava8Java

--- a/loki-logback-appender/build.gradle
+++ b/loki-logback-appender/build.gradle
@@ -162,7 +162,9 @@ signing {
     sign publishing.publications.mavenJava
 }
 
-apply from: '../gradle/java8.gradle'
+if (rootProject.hasProperty('java8')) {
+    apply from: '../gradle/java8.gradle'
+}
 
 tasks.withType(GenerateModuleMetadata) {
     enabled = false


### PR DESCRIPTION
This should fix project import and compilation in IDEs.