### PR TITLE
Expire streams eventually to avoid high memory consumption

### DIFF
--- a/loki-logback-appender/build.gradle
+++ b/loki-logback-appender/build.gradle
@@ -29,6 +29,7 @@ sourceSets {
 
 dependencies {
     api libs.logback
+    implementation libs.caffeine
 
     compileOnly libs.bundles.pluggable
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ dependencyResolutionManagement {
 
             alias('logback').to('ch.qos.logback:logback-classic:1.2.3')
             alias('jackson').to('com.fasterxml.jackson.core:jackson-databind:2.12.4')
+            alias('caffeine').to('com.github.ben-manes.caffeine:caffeine:3.0.5')
 
             alias('junit').to('junit:junit:4.13.2')
 


### PR DESCRIPTION
Ahoy, I've noticed in certain circumstances (very high cardinality labels, long uptime), a high memory consumption by the loki4j Logback Appender is possible.

![image](https://user-images.githubusercontent.com/6048348/149632569-a695e617-3ae4-4e10-8425-ed6d90fe23cc.png)
![image](https://user-images.githubusercontent.com/6048348/149632584-60660a3f-622c-4ad3-9bb2-5c719e00d19d.png)

The root cause appears to be that the `AbstractLoki4jEncoder` class contains a HashMap of `LogRecordStream`s that is only ever appended to, never cleaned up. If the labels which are used as keys have a high cardinality, this map tends to accumulate a lot of entries over time.

A simple solution could be to expire entries from that map eventually, which I have implemented here with the help of a [popular caching library, Caffeine](https://github.com/ben-manes/caffeine).
I might have jumped the gun here a bit by not opening an issue to discuss possible solutions first, as not every project might be happy to include a dependency just for one use case, please do suggest acceptable alternatives in that case.