### PR TITLE
Switch integration test from Loki 2.4.1 to Loki 2.4.2

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -24,8 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 11
       - name: Build and Run Integration Tests
         run: |
@@ -56,9 +57,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 11.0.13
       - name: Build and Run Integration Tests
         env:
           GRAFANA_CLOUD_USERNAME: ${{ secrets.GRAFANA_CLOUD_USERNAME }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -56,7 +56,7 @@ jobs:
     environment: integ-tests
     strategy:
       matrix:
-        jdk: [11.0.13, 11.0.14, 17.0.1, 17.0.2]
+        jdk: [11.0.13, 11.0.14, 17.0.0, 17.0.1]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 11.0.13
+          java-version: 11
       - name: Build and Run Integration Tests
         env:
           GRAFANA_CLOUD_USERNAME: ${{ secrets.GRAFANA_CLOUD_USERNAME }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -56,7 +56,7 @@ jobs:
     environment: integ-tests
     strategy:
       matrix:
-        jdk: [11.0.13, 11.0.14, 17.0.0, 17.0.1]
+        jdk: [11, 17]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -54,13 +54,16 @@ jobs:
   grafana-cloud:
     runs-on: ubuntu-latest
     environment: integ-tests
+    strategy:
+      matrix:
+        jdk: [11.0.13, 11.0.14, 17.0.1, 17.0.2]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 11.0.13
+          java-version: ${{ matrix.jdk }}
       - name: Build and Run Integration Tests
         env:
           GRAFANA_CLOUD_USERNAME: ${{ secrets.GRAFANA_CLOUD_USERNAME }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        loki: [1.6.1, 2.4.1]
+        loki: [1.6.1, 2.4.2]
         include:
           - loki: 1.6.1
             limits: -distributor.ingestion-rate-limit-mb=160 -distributor.ingestion-burst-size-mb=240
-          - loki: 2.4.1
+          - loki: 2.4.2
             limits: |
               -distributor.ingestion-rate-limit-mb=160 -distributor.ingestion-burst-size-mb=240 \
               -ingester.per-stream-rate-limit="80MB" -ingester.per-stream-rate-limit-burst="160MB" \

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 11.0.13
       - name: Build and Run Integration Tests
         env:
           GRAFANA_CLOUD_USERNAME: ${{ secrets.GRAFANA_CLOUD_USERNAME }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -68,6 +68,7 @@ jobs:
         env:
           GRAFANA_CLOUD_USERNAME: ${{ secrets.GRAFANA_CLOUD_USERNAME }}
           GRAFANA_CLOUD_PASSWORD: ${{ secrets.GRAFANA_CLOUD_PASSWORD }}
+          GRAFANA_CLOUD_EXTRA_LABEL: -JDK${{ matrix.jdk }}
         run: |
           ./gradlew check
           ./gradlew ciOnlyTests --tests "*GrafanaCloudTest"

--- a/loki-client/src/main/java/com/github/loki4j/client/http/JavaHttpClient.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/http/JavaHttpClient.java
@@ -2,6 +2,7 @@ package com.github.loki4j.client.http;
 
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
@@ -38,6 +39,7 @@ public final class JavaHttpClient implements Loki4jHttpClient {
 
         client = HttpClient
             .newBuilder()
+            .version(Version.HTTP_1_1)
             .connectTimeout(Duration.ofMillis(conf.connectionTimeoutMs))
             .executor(internalHttpThreadPool)
             .build();

--- a/loki-client/src/main/java/com/github/loki4j/client/http/JavaHttpClient.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/http/JavaHttpClient.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.http.HttpClient.Version;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
@@ -39,7 +38,6 @@ public final class JavaHttpClient implements Loki4jHttpClient {
 
         client = HttpClient
             .newBuilder()
-            .version(Version.HTTP_1_1)
             .connectTimeout(Duration.ofMillis(conf.connectionTimeoutMs))
             .executor(internalHttpThreadPool)
             .build();

--- a/loki-client/src/main/java/com/github/loki4j/client/http/JavaHttpClient.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/http/JavaHttpClient.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpClient.Version;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
@@ -38,6 +39,7 @@ public final class JavaHttpClient implements Loki4jHttpClient {
 
         client = HttpClient
             .newBuilder()
+            .version(Version.HTTP_1_1)
             .connectTimeout(Duration.ofMillis(conf.connectionTimeoutMs))
             .executor(internalHttpThreadPool)
             .build();

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/GrafanaCloudTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/GrafanaCloudTest.java
@@ -18,6 +18,7 @@ public class GrafanaCloudTest {
 
     private static String username = System.getenv("GRAFANA_CLOUD_USERNAME");
     private static String password = System.getenv("GRAFANA_CLOUD_PASSWORD");
+    private static String extraLabel = System.getenv("GRAFANA_CLOUD_EXTRA_LABEL");
 
     private static LokiTestingClient client;
 
@@ -31,7 +32,13 @@ public class GrafanaCloudTest {
         client.close();
     }
 
-    public static AbstractHttpSender authorize(AbstractHttpSender sender) {
+    private static String label(String l) {
+        return extraLabel == null
+            ? l
+            : l + extraLabel;
+    }
+
+    private static AbstractHttpSender authorize(AbstractHttpSender sender) {
         var auth = new AbstractHttpSender.BasicAuth();
         auth.setUsername(username);
         auth.setPassword(password);
@@ -44,7 +51,7 @@ public class GrafanaCloudTest {
     @Test
     @Category({CIOnlyTests.class})
     public void testApacheJsonCloud() throws Exception {
-        var label = "testApacheJsonCloud";
+        var label = label("testApacheJsonCloud");
         var encoder = jsonEncoder(false, label);
         var sender = authorize(apacheHttpSender(urlPush));
         var appender = appender(10, 1000, encoder, sender);
@@ -58,7 +65,7 @@ public class GrafanaCloudTest {
     @Test
     @Category({CIOnlyTests.class})
     public void testJavaJsonCloud() throws Exception {
-        var label = "testJavaJsonCloud";
+        var label = label("testJavaJsonCloud");
         var encoder = jsonEncoder(false, label);
         var sender = authorize(javaHttpSender(urlPush));
         var appender = appender(10, 1000, encoder, sender);
@@ -70,7 +77,7 @@ public class GrafanaCloudTest {
     @Test
     @Category({CIOnlyTests.class})
     public void testApacheProtobufCloud() throws Exception {
-        var label = "testApacheProtobufCloud";
+        var label = label("testApacheProtobufCloud");
         var encoder = protobufEncoder(false, label);
         var sender = authorize(apacheHttpSender(urlPush));
         var appender = appender(10, 1000, encoder, sender);
@@ -82,7 +89,7 @@ public class GrafanaCloudTest {
     @Test
     @Category({CIOnlyTests.class})
     public void testJavaProtobufCloud() throws Exception {
-        var label = "testJavaProtobufCloud";
+        var label = label("testJavaProtobufCloud");
         var encoder = protobufEncoder(false, label);
         var sender = authorize(javaHttpSender(urlPush));
         var appender = appender(10, 1000, encoder, sender);
@@ -94,7 +101,7 @@ public class GrafanaCloudTest {
     @Test
     @Category({CIOnlyTests.class})
     public void testApacheJsonMaxBytesSend() throws Exception {
-        var label = "testApacheJsonMaxBytesSendCloud";
+        var label = label("testApacheJsonMaxBytesSendCloud");
         var encoder = jsonEncoder(false, label);
         var sender = authorize(apacheHttpSender(urlPush));
         sender.setRequestTimeoutMs(30_000L);
@@ -111,7 +118,7 @@ public class GrafanaCloudTest {
     @Test
     @Category({CIOnlyTests.class})
     public void testJavaProtobufMaxBytesSend() throws Exception {
-        var label = "testJavaProtobufMaxBytesSendCloud";
+        var label = label("testJavaProtobufMaxBytesSendCloud");
         var encoder = protobufEncoder(false, label);
         var sender = authorize(javaHttpSender(urlPush));
         sender.setRequestTimeoutMs(30_000L);

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/LokiTestingClient.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/LokiTestingClient.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
@@ -51,6 +52,7 @@ public class LokiTestingClient {
 
         client = HttpClient
             .newBuilder()
+            .version(Version.HTTP_1_1)
             .connectTimeout(Duration.ofSeconds(120))
             .build();
 


### PR DESCRIPTION
Apart from switching Loki to 2.4.2 the following changes were introduced:

1. JavaHttpClient explicitly configured to run HTTP/1.1 queries. The issues with HTTP/2.0 was detected for GrafanaCloud on JDK 11.0.14 and 17.0.*
2. GrafanaCloud integration test now runs on multiple JDK versions
3. Started upgrade of setup-java github action to v2