### PR TITLE
Update protobuf-java in the docs to fix CVE

### DIFF
--- a/docs/docus/docs/configuration.md
+++ b/docs/docus/docs/configuration.md
@@ -102,7 +102,7 @@ If you want to use `ProtobufEncoder`, you need to add Protobuf-related dependenc
 <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java</artifactId>
-    <version>3.18.1</version>
+    <version>3.18.2</version>
 </dependency>
 <dependency>
     <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
https://advisory.checkmarx.net/advisory/vulnerability/CVE-2021-22569/

Intellij told me that this version of protobuf-java has a CVE filed against it.