### PR TITLE
JSON message layout support

### DIFF
--- a/loki-client/src/main/java/com/github/loki4j/pkg/dslplatform/json/NumberConverter.java
+++ b/loki-client/src/main/java/com/github/loki4j/pkg/dslplatform/json/NumberConverter.java
@@ -3,121 +3,27 @@ package com.github.loki4j.pkg.dslplatform.json;
 public class NumberConverter {
 
     private static final byte MINUS = '-';
-    private static final int[] DIGITS = new int[1000];
-    private static final byte[] MIN_LONG = "-9223372036854775808".getBytes();
+    private static final byte ZERO = '0';
+    private static final byte[] DIGITS = new byte[40];
 
-	public static void serialize(final long value, final RawJsonWriter sw) {
-		final byte[] buf = sw.ensureCapacity(21);
-		final int position = sw.size();
-		int current = serialize(buf, position, value);
-		sw.advance(current - position);
-	}
-
-	private static int serialize(final byte[] buf, int pos, final long value) {
-		long i;
-		if (value < 0) {
-			if (value == Long.MIN_VALUE) {
-				for (int x = 0; x < MIN_LONG.length; x++) {
-					buf[pos + x] = MIN_LONG[x];
-				}
-				return pos + MIN_LONG.length;
-			}
-			i = -value;
-			buf[pos++] = MINUS;
-		} else {
-			i = value;
-		}
-		final long q1 = i / 1000;
-		if (q1 == 0) {
-			pos += writeFirstBuf(buf, DIGITS[(int) i], pos);
-			return pos;
-		}
-		final int r1 = (int) (i - q1 * 1000);
-		final long q2 = q1 / 1000;
-		if (q2 == 0) {
-			final int v1 = DIGITS[r1];
-			final int v2 = DIGITS[(int) q1];
-			int off = writeFirstBuf(buf, v2, pos);
-			writeBuf(buf, v1, pos + off);
-			return pos + 3 + off;
-		}
-		final int r2 = (int) (q1 - q2 * 1000);
-		final long q3 = q2 / 1000;
-		if (q3 == 0) {
-			final int v1 = DIGITS[r1];
-			final int v2 = DIGITS[r2];
-			final int v3 = DIGITS[(int) q2];
-			pos += writeFirstBuf(buf, v3, pos);
-			writeBuf(buf, v2, pos);
-			writeBuf(buf, v1, pos + 3);
-			return pos + 6;
-		}
-		final int r3 = (int) (q2 - q3 * 1000);
-		final int q4 = (int) (q3 / 1000);
-		if (q4 == 0) {
-			final int v1 = DIGITS[r1];
-			final int v2 = DIGITS[r2];
-			final int v3 = DIGITS[r3];
-			final int v4 = DIGITS[(int) q3];
-			pos += writeFirstBuf(buf, v4, pos);
-			writeBuf(buf, v3, pos);
-			writeBuf(buf, v2, pos + 3);
-			writeBuf(buf, v1, pos + 6);
-			return pos + 9;
-		}
-		final int r4 = (int) (q3 - q4 * 1000);
-		final int q5 = q4 / 1000;
-		if (q5 == 0) {
-			final int v1 = DIGITS[r1];
-			final int v2 = DIGITS[r2];
-			final int v3 = DIGITS[r3];
-			final int v4 = DIGITS[r4];
-			final int v5 = DIGITS[q4];
-			pos += writeFirstBuf(buf, v5, pos);
-			writeBuf(buf, v4, pos);
-			writeBuf(buf, v3, pos + 3);
-			writeBuf(buf, v2, pos + 6);
-			writeBuf(buf, v1, pos + 9);
-			return pos + 12;
-		}
-		final int r5 = q4 - q5 * 1000;
-		final int q6 = q5 / 1000;
-		final int v1 = DIGITS[r1];
-		final int v2 = DIGITS[r2];
-		final int v3 = DIGITS[r3];
-		final int v4 = DIGITS[r4];
-		final int v5 = DIGITS[r5];
-		if (q6 == 0) {
-			pos += writeFirstBuf(buf, DIGITS[q5], pos);
-		} else {
-			final int r6 = q5 - q6 * 1000;
-			buf[pos++] = (byte) (q6 + '0');
-			writeBuf(buf, DIGITS[r6], pos);
-			pos += 3;
-		}
-		writeBuf(buf, v5, pos);
-		writeBuf(buf, v4, pos + 3);
-		writeBuf(buf, v3, pos + 6);
-		writeBuf(buf, v2, pos + 9);
-		writeBuf(buf, v1, pos + 12);
-		return pos + 15;
-	}
-
-    private static int writeFirstBuf(final byte[] buf, final int v, int pos) {
-		final int start = v >> 24;
-		if (start == 0) {
-			buf[pos++] = (byte) (v >> 16);
-			buf[pos++] = (byte) (v >> 8);
-		} else if (start == 1) {
-			buf[pos++] = (byte) (v >> 8);
-		}
-		buf[pos] = (byte) v;
-		return 3 - start;
-	}
-
-	private static void writeBuf(final byte[] buf, final int v, int pos) {
-		buf[pos] = (byte) (v >> 16);
-		buf[pos + 1] = (byte) (v >> 8);
-		buf[pos + 2] = (byte) v;
-	}
+    public static void serialize(final long value, final RawJsonWriter sw) {
+        var num = value;
+        if (num == 0) {
+            sw.writeByte(ZERO);
+            return;
+        }
+        if (num < 0) {
+            sw.writeByte(MINUS);
+            num = -num;
+        }
+        var pos = 0;
+        while (num != 0) {
+            DIGITS[pos++] = (byte) (num % 10);
+            num = num / 10;
+        }
+        while (pos > 0) {
+            byte digit = (byte) (ZERO + DIGITS[--pos]);
+            sw.writeByte(digit);
+        }
+    }
 }

--- a/loki-client/src/main/java/com/github/loki4j/pkg/dslplatform/json/NumberConverter.java
+++ b/loki-client/src/main/java/com/github/loki4j/pkg/dslplatform/json/NumberConverter.java
@@ -1,0 +1,123 @@
+package com.github.loki4j.pkg.dslplatform.json;
+
+public class NumberConverter {
+
+    private static final byte MINUS = '-';
+    private static final int[] DIGITS = new int[1000];
+    private static final byte[] MIN_LONG = "-9223372036854775808".getBytes();
+
+	public static void serialize(final long value, final RawJsonWriter sw) {
+		final byte[] buf = sw.ensureCapacity(21);
+		final int position = sw.size();
+		int current = serialize(buf, position, value);
+		sw.advance(current - position);
+	}
+
+	private static int serialize(final byte[] buf, int pos, final long value) {
+		long i;
+		if (value < 0) {
+			if (value == Long.MIN_VALUE) {
+				for (int x = 0; x < MIN_LONG.length; x++) {
+					buf[pos + x] = MIN_LONG[x];
+				}
+				return pos + MIN_LONG.length;
+			}
+			i = -value;
+			buf[pos++] = MINUS;
+		} else {
+			i = value;
+		}
+		final long q1 = i / 1000;
+		if (q1 == 0) {
+			pos += writeFirstBuf(buf, DIGITS[(int) i], pos);
+			return pos;
+		}
+		final int r1 = (int) (i - q1 * 1000);
+		final long q2 = q1 / 1000;
+		if (q2 == 0) {
+			final int v1 = DIGITS[r1];
+			final int v2 = DIGITS[(int) q1];
+			int off = writeFirstBuf(buf, v2, pos);
+			writeBuf(buf, v1, pos + off);
+			return pos + 3 + off;
+		}
+		final int r2 = (int) (q1 - q2 * 1000);
+		final long q3 = q2 / 1000;
+		if (q3 == 0) {
+			final int v1 = DIGITS[r1];
+			final int v2 = DIGITS[r2];
+			final int v3 = DIGITS[(int) q2];
+			pos += writeFirstBuf(buf, v3, pos);
+			writeBuf(buf, v2, pos);
+			writeBuf(buf, v1, pos + 3);
+			return pos + 6;
+		}
+		final int r3 = (int) (q2 - q3 * 1000);
+		final int q4 = (int) (q3 / 1000);
+		if (q4 == 0) {
+			final int v1 = DIGITS[r1];
+			final int v2 = DIGITS[r2];
+			final int v3 = DIGITS[r3];
+			final int v4 = DIGITS[(int) q3];
+			pos += writeFirstBuf(buf, v4, pos);
+			writeBuf(buf, v3, pos);
+			writeBuf(buf, v2, pos + 3);
+			writeBuf(buf, v1, pos + 6);
+			return pos + 9;
+		}
+		final int r4 = (int) (q3 - q4 * 1000);
+		final int q5 = q4 / 1000;
+		if (q5 == 0) {
+			final int v1 = DIGITS[r1];
+			final int v2 = DIGITS[r2];
+			final int v3 = DIGITS[r3];
+			final int v4 = DIGITS[r4];
+			final int v5 = DIGITS[q4];
+			pos += writeFirstBuf(buf, v5, pos);
+			writeBuf(buf, v4, pos);
+			writeBuf(buf, v3, pos + 3);
+			writeBuf(buf, v2, pos + 6);
+			writeBuf(buf, v1, pos + 9);
+			return pos + 12;
+		}
+		final int r5 = q4 - q5 * 1000;
+		final int q6 = q5 / 1000;
+		final int v1 = DIGITS[r1];
+		final int v2 = DIGITS[r2];
+		final int v3 = DIGITS[r3];
+		final int v4 = DIGITS[r4];
+		final int v5 = DIGITS[r5];
+		if (q6 == 0) {
+			pos += writeFirstBuf(buf, DIGITS[q5], pos);
+		} else {
+			final int r6 = q5 - q6 * 1000;
+			buf[pos++] = (byte) (q6 + '0');
+			writeBuf(buf, DIGITS[r6], pos);
+			pos += 3;
+		}
+		writeBuf(buf, v5, pos);
+		writeBuf(buf, v4, pos + 3);
+		writeBuf(buf, v3, pos + 6);
+		writeBuf(buf, v2, pos + 9);
+		writeBuf(buf, v1, pos + 12);
+		return pos + 15;
+	}
+
+    private static int writeFirstBuf(final byte[] buf, final int v, int pos) {
+		final int start = v >> 24;
+		if (start == 0) {
+			buf[pos++] = (byte) (v >> 16);
+			buf[pos++] = (byte) (v >> 8);
+		} else if (start == 1) {
+			buf[pos++] = (byte) (v >> 8);
+		}
+		buf[pos] = (byte) v;
+		return 3 - start;
+	}
+
+	private static void writeBuf(final byte[] buf, final int v, int pos) {
+		buf[pos] = (byte) (v >> 16);
+		buf[pos + 1] = (byte) (v >> 8);
+		buf[pos + 2] = (byte) v;
+	}
+}

--- a/loki-client/src/main/java/com/github/loki4j/pkg/dslplatform/json/RawJsonWriter.java
+++ b/loki-client/src/main/java/com/github/loki4j/pkg/dslplatform/json/RawJsonWriter.java
@@ -29,6 +29,7 @@
 package com.github.loki4j.pkg.dslplatform.json;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class RawJsonWriter {
@@ -340,6 +341,11 @@ public class RawJsonWriter {
         b.put(buffer, 0, position);
         b.flip();
         reset();
+    }
+
+    @Override
+    public String toString() {
+        return new String(buffer, 0, position, StandardCharsets.UTF_8);
     }
 
     /**

--- a/loki-client/src/main/java/com/github/loki4j/pkg/dslplatform/json/RawJsonWriter.java
+++ b/loki-client/src/main/java/com/github/loki4j/pkg/dslplatform/json/RawJsonWriter.java
@@ -345,7 +345,9 @@ public class RawJsonWriter {
 
     @Override
     public String toString() {
-        return new String(buffer, 0, position, StandardCharsets.UTF_8);
+        var r = new String(buffer, 0, position, StandardCharsets.UTF_8);
+        reset();
+        return r;
     }
 
     /**

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
@@ -1,6 +1,7 @@
 package com.github.loki4j.logback;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -86,7 +87,7 @@ public abstract class AbstractLoki4jEncoder extends ContextAwareBase implements 
         }
     }
 
-    protected final Charset charset = Charset.forName("UTF-8");
+    protected final Charset charset = StandardCharsets.UTF_8;
 
     private final AtomicInteger nanoCounter = new AtomicInteger(0);
 

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
@@ -109,7 +109,7 @@ public abstract class AbstractLoki4jEncoder extends ContextAwareBase implements 
     private Pattern compiledLabelKeyValueSeparator;
 
     private PatternLayout labelPatternLayout;
-    private Layout<ILoggingEvent> message;
+    private Layout<ILoggingEvent> messageLayout;
 
     private LogRecordStream staticLabelStream = null;
 
@@ -141,19 +141,19 @@ public abstract class AbstractLoki4jEncoder extends ContextAwareBase implements 
         labelPatternLayout.setContext(context);
         labelPatternLayout.start();
 
-        if (message == null) {
+        if (messageLayout == null) {
             addWarn("No message layout specified in the config. Using PatternLayout with default settings");
-            message = initPatternLayout(DEFAULT_MSG_PATTERN);
+            messageLayout = initPatternLayout(DEFAULT_MSG_PATTERN);
         }
-        message.setContext(context);
-        message.start();
+        messageLayout.setContext(context);
+        messageLayout.start();
 
         this.started = true;
     }
 
     public void stop() {
         this.started = false;
-        message.stop();
+        messageLayout.stop();
         labelPatternLayout.stop();
     }
 
@@ -195,7 +195,7 @@ public abstract class AbstractLoki4jEncoder extends ContextAwareBase implements 
     }
 
     public String eventToMessage(ILoggingEvent e) {
-        return message.doLayout(e);
+        return messageLayout.doLayout(e);
     }
 
     public int timestampToNanos(long timestampMs) {
@@ -269,7 +269,7 @@ public abstract class AbstractLoki4jEncoder extends ContextAwareBase implements 
 
     @DefaultClass(PatternLayout.class)
     public void setMessage(Layout<ILoggingEvent> message) {
-        this.message = message;
+        this.messageLayout = message;
     }
 
     public boolean getSortByTime() {

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
@@ -144,9 +144,9 @@ public abstract class AbstractLoki4jEncoder extends ContextAwareBase implements 
         if (messageLayout == null) {
             addWarn("No message layout specified in the config. Using PatternLayout with default settings");
             messageLayout = initPatternLayout(DEFAULT_MSG_PATTERN);
-            messageLayout.setContext(context);
-            messageLayout.start();
         }
+        messageLayout.setContext(context);
+        messageLayout.start();
 
         this.started = true;
     }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
@@ -144,9 +144,9 @@ public abstract class AbstractLoki4jEncoder extends ContextAwareBase implements 
         if (messageLayout == null) {
             addWarn("No message layout specified in the config. Using PatternLayout with default settings");
             messageLayout = initPatternLayout(DEFAULT_MSG_PATTERN);
+            messageLayout.setContext(context);
+            messageLayout.start();
         }
-        messageLayout.setContext(context);
-        messageLayout.start();
 
         this.started = true;
     }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
@@ -84,6 +84,15 @@ public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent
                 mdc
         );
 
+        for (var provider : providers) {
+            provider.setContext(context);
+            provider.start();
+        }
+        for (var provider : customProviders) {
+            provider.setContext(context);
+            provider.start();
+        }
+
         started = true;
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
@@ -1,0 +1,77 @@
+package com.github.loki4j.logback;
+
+import java.util.List;
+
+import com.github.loki4j.logback.json.JsonEventWriter;
+import com.github.loki4j.logback.json.JsonProvider;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Layout;
+import ch.qos.logback.core.spi.ContextAwareBase;
+
+public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent> {
+
+    private static String EMPTY_STRING = "";
+
+    private volatile boolean started;
+
+    private JsonEventWriter jsonWriter;
+
+    private List<JsonProvider<ILoggingEvent>> providers;
+
+    private List<JsonProvider<ILoggingEvent>> customProviders;
+
+    @Override
+    public String doLayout(ILoggingEvent event) {
+        jsonWriter.writeBeginObject();
+        for (var provider : providers) {
+            provider.writeTo(jsonWriter, event);
+        }
+        for (var provider : customProviders) {
+            provider.writeTo(jsonWriter, event);
+        }
+        jsonWriter.writeEndObject();
+        return jsonWriter.toString();
+    }
+
+    @Override
+    public void start() {
+        started = true;
+    }
+    
+    @Override
+    public void stop() {
+        started = false;
+    }
+    
+    @Override
+    public boolean isStarted() {
+        return started;
+    }
+
+    @Override
+    public String getFileHeader() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getPresentationHeader() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getPresentationFooter() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getFileFooter() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getContentType() {
+        return "application/json";
+    }
+    
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
@@ -6,7 +6,9 @@ import com.github.loki4j.logback.json.JsonEventWriter;
 import com.github.loki4j.logback.json.JsonProvider;
 import com.github.loki4j.logback.json.LogLevelJsonProvider;
 import com.github.loki4j.logback.json.LoggerNameJsonProvider;
+import com.github.loki4j.logback.json.MdcJsonProvider;
 import com.github.loki4j.logback.json.MessageJsonProvider;
+import com.github.loki4j.logback.json.StackTraceJsonProvider;
 import com.github.loki4j.logback.json.ThreadNameJsonProvider;
 import com.github.loki4j.logback.json.TimestampJsonProvider;
 
@@ -27,7 +29,9 @@ public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent
             new LoggerNameJsonProvider(),
             new LogLevelJsonProvider(),
             new ThreadNameJsonProvider(),
-            new MessageJsonProvider()
+            new MessageJsonProvider(),
+            new StackTraceJsonProvider(),
+            new MdcJsonProvider()
     );
 
     private List<JsonProvider<ILoggingEvent>> customProviders = List.of();
@@ -36,13 +40,18 @@ public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent
     public String doLayout(ILoggingEvent event) {
         var standard = providers.iterator();
         var custom = customProviders.iterator();
+        var firstFieldWritten = false;
         jsonWriter.writeBeginObject();
         while (standard.hasNext() || custom.hasNext()) {
             var provider = standard.hasNext() ? standard.next() : custom.next();
-            provider.writeTo(jsonWriter, event);
-            if (standard.hasNext() || custom.hasNext()) {
+            if (!provider.canWrite(event))
+                continue;
+
+            if (firstFieldWritten)
                 jsonWriter.writeFieldSeparator();
-            }
+            provider.writeTo(jsonWriter, event);
+
+            firstFieldWritten = true;
         }
         jsonWriter.writeEndObject();
         return jsonWriter.toString();

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
@@ -1,6 +1,7 @@
 package com.github.loki4j.logback;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -55,11 +56,7 @@ public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent
             if (!provider.isEnabled() || !provider.canWrite(event))
                 continue;
 
-            if (firstFieldWritten)
-                jsonWriter.writeFieldSeparator();
-            provider.writeTo(jsonWriter, event);
-
-            firstFieldWritten = true;
+            firstFieldWritten = provider.writeTo(jsonWriter, event, firstFieldWritten) || firstFieldWritten;
         }
         jsonWriter.writeEndObject();
         return jsonWriter.toString();
@@ -77,7 +74,7 @@ public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent
         stackTrace = ensureProvider(stackTrace, StackTraceJsonProvider::new);
         mdc = ensureProvider(mdc, MdcJsonProvider::new);
 
-        providers = List.of(
+        providers = Arrays.asList(
                 timestamp,
                 loggerName,
                 logLevel,

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/JsonLayout.java
@@ -1,6 +1,7 @@
 package com.github.loki4j.logback;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import com.github.loki4j.logback.json.JsonEventWriter;
 import com.github.loki4j.logback.json.JsonProvider;
@@ -18,21 +19,21 @@ import ch.qos.logback.core.spi.ContextAwareBase;
 
 public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent> {
 
-    private static String EMPTY_STRING = "";
+    private static final String EMPTY_STRING = "";
+
+    private TimestampJsonProvider timestamp;
+    private LoggerNameJsonProvider loggerName;
+    private LogLevelJsonProvider logLevel;
+    private ThreadNameJsonProvider threadName;
+    private MessageJsonProvider message;
+    private StackTraceJsonProvider stackTrace;
+    private MdcJsonProvider mdc;
 
     private volatile boolean started;
 
     private JsonEventWriter jsonWriter;
 
-    private final List<JsonProvider<ILoggingEvent>> providers = List.of(
-            new TimestampJsonProvider(),
-            new LoggerNameJsonProvider(),
-            new LogLevelJsonProvider(),
-            new ThreadNameJsonProvider(),
-            new MessageJsonProvider(),
-            new StackTraceJsonProvider(),
-            new MdcJsonProvider()
-    );
+    private List<JsonProvider<ILoggingEvent>> providers;
 
     private List<JsonProvider<ILoggingEvent>> customProviders = List.of();
 
@@ -44,7 +45,7 @@ public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent
         jsonWriter.writeBeginObject();
         while (standard.hasNext() || custom.hasNext()) {
             var provider = standard.hasNext() ? standard.next() : custom.next();
-            if (!provider.canWrite(event))
+            if (!provider.isEnabled() || !provider.canWrite(event))
                 continue;
 
             if (firstFieldWritten)
@@ -61,10 +62,24 @@ public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent
     public void start() {
         jsonWriter = new JsonEventWriter(100);  // TODO: fix hardcoding
 
-        for (var provider : providers) {
-            provider.setContext(context);
-            provider.start();
-        }
+        timestamp = ensureProvider(timestamp, TimestampJsonProvider::new);
+        loggerName = ensureProvider(loggerName, LoggerNameJsonProvider::new);
+        logLevel = ensureProvider(logLevel, LogLevelJsonProvider::new);
+        threadName = ensureProvider(threadName, ThreadNameJsonProvider::new);
+        message = ensureProvider(message, MessageJsonProvider::new);
+        stackTrace = ensureProvider(stackTrace, StackTraceJsonProvider::new);
+        mdc = ensureProvider(mdc, MdcJsonProvider::new);
+
+        providers = List.of(
+                timestamp,
+                loggerName,
+                logLevel,
+                threadName,
+                message,
+                stackTrace,
+                mdc
+        );
+
         for (var provider : customProviders) {
             provider.setContext(context);
             provider.start();
@@ -84,7 +99,45 @@ public class JsonLayout extends ContextAwareBase implements Layout<ILoggingEvent
             provider.stop();
         }
     }
-    
+
+    private <T extends JsonProvider<ILoggingEvent>> T ensureProvider(T current, Supplier<T> factory) {
+        if (current != null)
+            return current;
+
+        var newInstance = factory.get();
+        newInstance.setContext(context);
+        newInstance.start();
+        return newInstance;
+    }
+
+    public void setTimestamp(TimestampJsonProvider timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public void setLoggerName(LoggerNameJsonProvider loggerName) {
+        this.loggerName = loggerName;
+    }
+
+    public void setLogLevel(LogLevelJsonProvider logLevel) {
+        this.logLevel = logLevel;
+    }
+
+    public void setThreadName(ThreadNameJsonProvider threadName) {
+        this.threadName = threadName;
+    }
+
+    public void setMessage(MessageJsonProvider message) {
+        this.message = message;
+    }
+
+    public void setStackTrace(StackTraceJsonProvider stackTrace) {
+        this.stackTrace = stackTrace;
+    }
+
+    public void setMdc(MdcJsonProvider mdc) {
+        this.mdc = mdc;
+    }
+
     @Override
     public boolean isStarted() {
         return started;

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
@@ -20,6 +20,21 @@ public abstract class AbstractFieldJsonProvider extends ContextAwareBase impleme
     }
 
     @Override
+    public boolean writeTo(JsonEventWriter writer, ILoggingEvent event, boolean startWithSeparator) {
+        if (startWithSeparator)
+            writer.writeFieldSeparator();
+        writeExactlyOneField(writer, event);
+        return true;
+    }
+
+    /**
+     * Write exactly one field into JSON event layout.
+     * @param writer JSON writer to use.
+     * @param event Current logback event.
+     */
+    protected abstract void writeExactlyOneField(JsonEventWriter writer, ILoggingEvent event);
+
+    @Override
     public void start() {
         started = true;
     }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
@@ -13,6 +13,11 @@ public abstract class AbstractFieldJsonProvider extends ContextAwareBase impleme
     public void prepareForDeferredProcessing(ILoggingEvent event) { }
 
     @Override
+    public boolean canWrite(ILoggingEvent event) {
+        return true;
+    }
+
+    @Override
     public void start() {
         started = true;
     }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
@@ -1,0 +1,37 @@
+package com.github.loki4j.logback.json;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.ContextAwareBase;
+
+public abstract class AbstractFieldJsonProvider extends ContextAwareBase implements JsonProvider<ILoggingEvent> {
+
+    private String fieldName;
+
+    private volatile boolean started;
+    
+    @Override
+    public void prepareForDeferredProcessing(ILoggingEvent event) { }
+
+    @Override
+    public void start() {
+        started = true;
+    }
+    
+    @Override
+    public void stop() {
+        started = false;
+    }
+    
+    @Override
+    public boolean isStarted() {
+        return started;
+    }
+    
+    public String getFieldName() {
+        return fieldName;
+    }
+    
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
@@ -5,6 +5,8 @@ import ch.qos.logback.core.spi.ContextAwareBase;
 
 public abstract class AbstractFieldJsonProvider extends ContextAwareBase implements JsonProvider<ILoggingEvent> {
 
+    private boolean enabled = true;
+
     private String fieldName;
 
     private volatile boolean started;
@@ -31,7 +33,16 @@ public abstract class AbstractFieldJsonProvider extends ContextAwareBase impleme
     public boolean isStarted() {
         return started;
     }
-    
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
     public String getFieldName() {
         return fieldName;
     }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/AbstractFieldJsonProvider.java
@@ -3,6 +3,9 @@ package com.github.loki4j.logback.json;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.spi.ContextAwareBase;
 
+/**
+ * An abstract provider that writes a certain aspect of a logging event as a JSON field
+ */
 public abstract class AbstractFieldJsonProvider extends ContextAwareBase implements JsonProvider<ILoggingEvent> {
 
     private boolean enabled = true;
@@ -11,9 +14,6 @@ public abstract class AbstractFieldJsonProvider extends ContextAwareBase impleme
 
     private volatile boolean started;
     
-    @Override
-    public void prepareForDeferredProcessing(ILoggingEvent event) { }
-
     @Override
     public boolean canWrite(ILoggingEvent event) {
         return true;

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonEventWriter.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonEventWriter.java
@@ -5,6 +5,9 @@ import static com.github.loki4j.pkg.dslplatform.json.RawJsonWriter.*;
 import com.github.loki4j.pkg.dslplatform.json.NumberConverter;
 import com.github.loki4j.pkg.dslplatform.json.RawJsonWriter;
 
+/**
+ * A wrapper around {@link RawJsonWriter} that supports basic high-level write operations
+ */
 public class JsonEventWriter {
     
     private final RawJsonWriter raw;
@@ -40,5 +43,4 @@ public class JsonEventWriter {
     public String toString() {
         return raw.toString();
     }
-
 }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonEventWriter.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonEventWriter.java
@@ -1,0 +1,17 @@
+package com.github.loki4j.logback.json;
+
+import com.github.loki4j.pkg.dslplatform.json.RawJsonWriter;
+
+public class JsonEventWriter {
+    
+    //private final RawJsonWriter raw;
+
+    public void writeStringField(String fieldName, String value) {
+        // TODO: 
+    }
+
+    public void writeNumberField(String fieldName, Long value) {
+        // TODO: 
+    }
+
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonEventWriter.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonEventWriter.java
@@ -1,17 +1,44 @@
 package com.github.loki4j.logback.json;
 
+import static com.github.loki4j.pkg.dslplatform.json.RawJsonWriter.*;
+
+import com.github.loki4j.pkg.dslplatform.json.NumberConverter;
 import com.github.loki4j.pkg.dslplatform.json.RawJsonWriter;
 
 public class JsonEventWriter {
     
-    //private final RawJsonWriter raw;
+    private final RawJsonWriter raw;
+
+    public JsonEventWriter(int initialCapacity) {
+        raw = new RawJsonWriter(initialCapacity);
+    }
+
+    public void writeBeginObject() {
+        raw.writeByte(OBJECT_START);
+    }
+
+    public void writeEndObject() {
+        raw.writeByte(OBJECT_END);
+    }
+
+    public void writeFieldSeparator() {
+        raw.writeByte(COMMA);
+    }
 
     public void writeStringField(String fieldName, String value) {
-        // TODO: 
+        raw.writeAsciiString(fieldName);
+        raw.writeByte(SEMI);
+        raw.writeString(value);
     }
 
     public void writeNumberField(String fieldName, Long value) {
-        // TODO: 
+        raw.writeAsciiString(fieldName);
+        raw.writeByte(SEMI);
+        NumberConverter.serialize(value, raw);
+    }
+
+    public String toString() {
+        return raw.toString();
     }
 
 }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
@@ -4,6 +4,9 @@ import ch.qos.logback.core.spi.ContextAware;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 import ch.qos.logback.core.spi.LifeCycle;
 
+/**
+ * A provider that writes a certain aspect of a logging event to a JSON
+ */
 public interface JsonProvider<Event extends DeferredProcessingAware> extends ContextAware, LifeCycle {
 
     boolean isEnabled();
@@ -11,7 +14,4 @@ public interface JsonProvider<Event extends DeferredProcessingAware> extends Con
     boolean canWrite(Event event);
     
     void writeTo(JsonEventWriter writer, Event event);
-
-    void prepareForDeferredProcessing(Event event);
-
 }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
@@ -1,0 +1,15 @@
+package com.github.loki4j.logback.json;
+
+import java.io.IOException;
+
+import ch.qos.logback.core.spi.ContextAware;
+import ch.qos.logback.core.spi.DeferredProcessingAware;
+import ch.qos.logback.core.spi.LifeCycle;
+
+public interface JsonProvider<Event extends DeferredProcessingAware> extends ContextAware, LifeCycle {
+    
+    void writeTo(JsonEventWriter writer, Event event) throws IOException;
+
+    void prepareForDeferredProcessing(Event event);
+
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
@@ -9,9 +9,25 @@ import ch.qos.logback.core.spi.LifeCycle;
  */
 public interface JsonProvider<Event extends DeferredProcessingAware> extends ContextAware, LifeCycle {
 
+    /**
+     * Indicates if this provider is enabled.
+     * For a disabled provider no other its methods should be called.
+     */
     boolean isEnabled();
 
+    /**
+     * Indicates if this provider can write anything for a particular event.
+     * If this method returns {@code false}, {@code writeTo()} should not be called for a particular event.
+     * You can put all your preliminary checks here, no need to duplicated them in {@code writeTo()}.
+     */
     boolean canWrite(Event event);
     
-    void writeTo(JsonEventWriter writer, Event event);
+    /**
+     * Writes a certain aspect of event into a writer.
+     * @param writer JSON writer to use.
+     * @param event Current logback event.
+     * @param startWithSeparator If {@code true}, a separator should be written before writing anything else.
+     * @return If anything was effectively written during this call.
+     */
+    boolean writeTo(JsonEventWriter writer, Event event, boolean startWithSeparator);
 }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
@@ -1,14 +1,12 @@
 package com.github.loki4j.logback.json;
 
-import java.io.IOException;
-
 import ch.qos.logback.core.spi.ContextAware;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 import ch.qos.logback.core.spi.LifeCycle;
 
 public interface JsonProvider<Event extends DeferredProcessingAware> extends ContextAware, LifeCycle {
     
-    void writeTo(JsonEventWriter writer, Event event) throws IOException;
+    void writeTo(JsonEventWriter writer, Event event);
 
     void prepareForDeferredProcessing(Event event);
 

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
@@ -5,6 +5,8 @@ import ch.qos.logback.core.spi.DeferredProcessingAware;
 import ch.qos.logback.core.spi.LifeCycle;
 
 public interface JsonProvider<Event extends DeferredProcessingAware> extends ContextAware, LifeCycle {
+
+    boolean canWrite(Event event);
     
     void writeTo(JsonEventWriter writer, Event event);
 

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
@@ -16,6 +16,11 @@ public interface JsonProvider<Event extends DeferredProcessingAware> extends Con
     boolean isEnabled();
 
     /**
+     * Allows to configure if the provider is enabled.
+     */
+    void setEnabled(boolean enabled);
+
+    /**
      * Indicates if this provider can write anything for a particular event.
      * If this method returns {@code false}, {@code writeTo()} should not be called for a particular event.
      * You can put all your preliminary checks here, no need to duplicated them in {@code writeTo()}.

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/JsonProvider.java
@@ -6,6 +6,8 @@ import ch.qos.logback.core.spi.LifeCycle;
 
 public interface JsonProvider<Event extends DeferredProcessingAware> extends ContextAware, LifeCycle {
 
+    boolean isEnabled();
+
     boolean canWrite(Event event);
     
     void writeTo(JsonEventWriter writer, Event event);

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LogLevelJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LogLevelJsonProvider.java
@@ -1,7 +1,5 @@
 package com.github.loki4j.logback.json;
 
-import java.io.IOException;
-
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class LogLevelJsonProvider extends AbstractFieldJsonProvider {
@@ -13,7 +11,7 @@ public class LogLevelJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeStringField(getFieldName(), event.getLevel().toString());
     }
 }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LogLevelJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LogLevelJsonProvider.java
@@ -1,0 +1,19 @@
+package com.github.loki4j.logback.json;
+
+import java.io.IOException;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class LogLevelJsonProvider extends AbstractFieldJsonProvider {
+
+    public static final String FIELD_LEVEL = "level";
+    
+    public LogLevelJsonProvider() {
+        setFieldName(FIELD_LEVEL);
+    }
+
+    @Override
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+        writer.writeStringField(getFieldName(), event.getLevel().toString());
+    }
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LogLevelJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LogLevelJsonProvider.java
@@ -11,7 +11,7 @@ public class LogLevelJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
+    protected void writeExactlyOneField(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeStringField(getFieldName(), event.getLevel().toString());
     }
 }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
@@ -1,0 +1,20 @@
+package com.github.loki4j.logback.json;
+
+import java.io.IOException;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class LoggerNameJsonProvider extends AbstractFieldJsonProvider {
+
+    public static final String FIELD_LOGGER_NAME = "logger_name";
+
+    public LoggerNameJsonProvider() {
+        setFieldName(FIELD_LOGGER_NAME);
+    }
+
+    @Override
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+        writer.writeStringField(getFieldName(), event.getLoggerName());
+    }
+    
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
@@ -1,7 +1,5 @@
 package com.github.loki4j.logback.json;
 
-import java.io.IOException;
-
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class LoggerNameJsonProvider extends AbstractFieldJsonProvider {
@@ -13,7 +11,7 @@ public class LoggerNameJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeStringField(getFieldName(), event.getLoggerName());
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
@@ -1,6 +1,8 @@
 package com.github.loki4j.logback.json;
 
 import ch.qos.logback.classic.pattern.Abbreviator;
+import ch.qos.logback.classic.pattern.ClassNameOnlyAbbreviator;
+import ch.qos.logback.classic.pattern.TargetLengthBasedClassNameAbbreviator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class LoggerNameJsonProvider extends AbstractFieldJsonProvider {
@@ -8,12 +10,34 @@ public class LoggerNameJsonProvider extends AbstractFieldJsonProvider {
     public static final String FIELD_LOGGER_NAME = "logger_name";
 
     /**
-     * Abbreviator that will shorten the logger classname
+     * The desired target length:
+     * {@code -1} to disable abbreviation,
+     * {@code 0} to print class name only,
+     * {@code >0} to abbreviate to the target length.
      */
-    private Abbreviator abbreviator = new NoOpAbbreviator();
+    private int targetLength = -1;
+
+    private Abbreviator abbreviator;
 
     public LoggerNameJsonProvider() {
         setFieldName(FIELD_LOGGER_NAME);
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        if (targetLength > 0)
+            abbreviator = new TargetLengthBasedClassNameAbbreviator(targetLength);
+        else if (targetLength == 0)
+            abbreviator = new ClassNameOnlyAbbreviator();
+        else
+            abbreviator = new NoOpAbbreviator();
+    }
+
+    @Override
+    public void stop() {
+        abbreviator = null;
+        super.stop();
     }
 
     @Override
@@ -21,8 +45,8 @@ public class LoggerNameJsonProvider extends AbstractFieldJsonProvider {
         writer.writeStringField(getFieldName(), abbreviator.abbreviate(event.getLoggerName()));
     }
 
-    public void setAbbreviator(Abbreviator abbreviator) {
-        this.abbreviator = abbreviator;
+    public void setTargetLength(int targetLength) {
+        this.targetLength = targetLength;
     }
 
     public static class NoOpAbbreviator implements Abbreviator {

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
@@ -17,7 +17,7 @@ public class LoggerNameJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
+    protected void writeExactlyOneField(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeStringField(getFieldName(), abbreviator.abbreviate(event.getLoggerName()));
     }
 

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/LoggerNameJsonProvider.java
@@ -1,10 +1,16 @@
 package com.github.loki4j.logback.json;
 
+import ch.qos.logback.classic.pattern.Abbreviator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class LoggerNameJsonProvider extends AbstractFieldJsonProvider {
 
     public static final String FIELD_LOGGER_NAME = "logger_name";
+
+    /**
+     * Abbreviator that will shorten the logger classname
+     */
+    private Abbreviator abbreviator = new NoOpAbbreviator();
 
     public LoggerNameJsonProvider() {
         setFieldName(FIELD_LOGGER_NAME);
@@ -12,7 +18,17 @@ public class LoggerNameJsonProvider extends AbstractFieldJsonProvider {
 
     @Override
     public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
-        writer.writeStringField(getFieldName(), event.getLoggerName());
+        writer.writeStringField(getFieldName(), abbreviator.abbreviate(event.getLoggerName()));
     }
-    
+
+    public void setAbbreviator(Abbreviator abbreviator) {
+        this.abbreviator = abbreviator;
+    }
+
+    public static class NoOpAbbreviator implements Abbreviator {
+        @Override
+        public String abbreviate(String in) {
+            return in;
+        }
+    }
 }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MdcJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MdcJsonProvider.java
@@ -1,6 +1,5 @@
 package com.github.loki4j.logback.json;
 
-import java.io.IOException;
 import java.util.Map;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -14,7 +13,7 @@ public class MdcJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
          Map<String, String> mdcProperties = event.getMDCPropertyMap();
         if (mdcProperties != null && !mdcProperties.isEmpty()) {
             for (Map.Entry<String, String> entry : mdcProperties.entrySet()) {

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MdcJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MdcJsonProvider.java
@@ -11,7 +11,14 @@ public class MdcJsonProvider extends AbstractFieldJsonProvider {
     public static final String FIELD_MDC_PREFIX = "mdc_";
 
     /**
-     * An exclusive set of MDC keys to include into JSON payload
+     * A set of MDC keys to exclude from JSON payload.
+     * Exclude list has a precedence over include list
+     */
+    private Set<String> excludeKeys = new HashSet<>();
+
+    /**
+     * A set of MDC keys to include into JSON payload.
+     * Exclude list has a precedence over include list
      */
     private Set<String> includeKeys = new HashSet<>();
 
@@ -26,7 +33,7 @@ public class MdcJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
+    public boolean writeTo(JsonEventWriter writer, ILoggingEvent event, boolean startWithSeparator) {
         Map<String, String> mdcProperties = event.getMDCPropertyMap();
         var firstFieldWritten = false;
         for (Map.Entry<String, String> entry : mdcProperties.entrySet()) {
@@ -34,18 +41,34 @@ public class MdcJsonProvider extends AbstractFieldJsonProvider {
             if (entry.getKey() == null || entry.getValue() == null)
                 continue;
 
+            // check exclude list, if defined
+            if (!excludeKeys.isEmpty() && excludeKeys.contains(entry.getKey()))
+                continue;
+
             // check include list, if defined
             if (!includeKeys.isEmpty() && !includeKeys.contains(entry.getKey()))
                 continue;
 
-            if (firstFieldWritten)
+            if (startWithSeparator || firstFieldWritten)
                 writer.writeFieldSeparator();
             writer.writeStringField(getFieldName() + entry.getKey(), entry.getValue());
             firstFieldWritten = true;
         }
+        return firstFieldWritten;
+    }
+
+    @Override
+    protected void writeExactlyOneField(JsonEventWriter writer, ILoggingEvent event) {
+        throw new UnsupportedOperationException(
+            "MdcJsonProvider can write an arbitrary number of fields. `writeExactlyOneField` should never be called for MdcJsonProvider.");
+    }
+
+    public void addExclude(String key) {
+        excludeKeys.add(key);
     }
 
     public void addInclude(String key) {
         includeKeys.add(key);
     }
+
 }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MdcJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MdcJsonProvider.java
@@ -1,0 +1,26 @@
+package com.github.loki4j.logback.json;
+
+import java.io.IOException;
+import java.util.Map;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class MdcJsonProvider extends AbstractFieldJsonProvider {
+
+    public static final String FIELD_MDC_PREFIX = "mdc_";
+
+    public MdcJsonProvider() {
+        setFieldName(FIELD_MDC_PREFIX);
+    }
+
+    @Override
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+         Map<String, String> mdcProperties = event.getMDCPropertyMap();
+        if (mdcProperties != null && !mdcProperties.isEmpty()) {
+            for (Map.Entry<String, String> entry : mdcProperties.entrySet()) {
+                writer.writeStringField(getFieldName() + entry.getKey(), entry.getValue());
+            }
+        }
+    }
+    
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MdcJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MdcJsonProvider.java
@@ -13,12 +13,20 @@ public class MdcJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
+    public boolean canWrite(ILoggingEvent event) {
+        Map<String, String> mdcProperties = event.getMDCPropertyMap();
+        return mdcProperties != null && !mdcProperties.isEmpty();
+    }
+
+    @Override
     public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
-         Map<String, String> mdcProperties = event.getMDCPropertyMap();
-        if (mdcProperties != null && !mdcProperties.isEmpty()) {
-            for (Map.Entry<String, String> entry : mdcProperties.entrySet()) {
-                writer.writeStringField(getFieldName() + entry.getKey(), entry.getValue());
-            }
+        Map<String, String> mdcProperties = event.getMDCPropertyMap();
+        var firstFieldWritten = false;
+        for (Map.Entry<String, String> entry : mdcProperties.entrySet()) {
+            if (firstFieldWritten)
+                writer.writeFieldSeparator();
+            writer.writeStringField(getFieldName() + entry.getKey(), entry.getValue());
+            firstFieldWritten = true;
         }
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MessageJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MessageJsonProvider.java
@@ -1,0 +1,19 @@
+package com.github.loki4j.logback.json;
+
+import java.io.IOException;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class MessageJsonProvider extends AbstractFieldJsonProvider {
+
+    public static final String FIELD_MESSAGE = "message";
+
+    public MessageJsonProvider() {
+        setFieldName(FIELD_MESSAGE);
+    }
+
+    @Override
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+        writer.writeStringField(getFieldName(), event.getMessage());
+    }
+    
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MessageJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MessageJsonProvider.java
@@ -1,6 +1,5 @@
 package com.github.loki4j.logback.json;
 
-import java.io.IOException;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class MessageJsonProvider extends AbstractFieldJsonProvider {
@@ -12,7 +11,7 @@ public class MessageJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeStringField(getFieldName(), event.getMessage());
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MessageJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/MessageJsonProvider.java
@@ -11,7 +11,7 @@ public class MessageJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
+    protected void writeExactlyOneField(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeStringField(getFieldName(), event.getMessage());
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/StackTraceJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/StackTraceJsonProvider.java
@@ -1,7 +1,5 @@
 package com.github.loki4j.logback.json;
 
-import java.io.IOException;
-
 import ch.qos.logback.classic.pattern.ExtendedThrowableProxyConverter;
 import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -35,7 +33,7 @@ public class StackTraceJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
         IThrowableProxy throwableProxy = event.getThrowableProxy();
         if (throwableProxy != null) {
             writer.writeStringField(getFieldName(), throwableConverter.convert(event));

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/StackTraceJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/StackTraceJsonProvider.java
@@ -1,0 +1,52 @@
+package com.github.loki4j.logback.json;
+
+import java.io.IOException;
+
+import ch.qos.logback.classic.pattern.ExtendedThrowableProxyConverter;
+import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+
+public class StackTraceJsonProvider extends AbstractFieldJsonProvider {
+
+    public static final String FIELD_STACK_TRACE = "stack_trace";
+
+    /**
+     * Used to format throwables as Strings.
+     *
+     * Uses an {@link ExtendedThrowableProxyConverter} by default.
+     */
+    private ThrowableHandlingConverter throwableConverter = new ExtendedThrowableProxyConverter();
+
+    public StackTraceJsonProvider() {
+        setFieldName(FIELD_STACK_TRACE);
+    }
+
+    @Override
+    public void start() {
+        this.throwableConverter.start();
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        this.throwableConverter.stop();
+        super.stop();
+    }
+
+    @Override
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        if (throwableProxy != null) {
+            writer.writeStringField(getFieldName(), throwableConverter.convert(event));
+        }
+    }
+
+    public ThrowableHandlingConverter getThrowableConverter() {
+        return throwableConverter;
+    }
+
+    public void setThrowableConverter(ThrowableHandlingConverter throwableConverter) {
+        this.throwableConverter = throwableConverter;
+    }
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/StackTraceJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/StackTraceJsonProvider.java
@@ -37,7 +37,7 @@ public class StackTraceJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
+    protected void writeExactlyOneField(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeStringField(getFieldName(), throwableConverter.convert(event));
     }
 

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/StackTraceJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/StackTraceJsonProvider.java
@@ -3,7 +3,6 @@ package com.github.loki4j.logback.json;
 import ch.qos.logback.classic.pattern.ExtendedThrowableProxyConverter;
 import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.IThrowableProxy;
 
 public class StackTraceJsonProvider extends AbstractFieldJsonProvider {
 
@@ -33,11 +32,13 @@ public class StackTraceJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
+    public boolean canWrite(ILoggingEvent event) {
+        return event.getThrowableProxy() != null;
+    }
+
+    @Override
     public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
-        IThrowableProxy throwableProxy = event.getThrowableProxy();
-        if (throwableProxy != null) {
-            writer.writeStringField(getFieldName(), throwableConverter.convert(event));
-        }
+        writer.writeStringField(getFieldName(), throwableConverter.convert(event));
     }
 
     public ThrowableHandlingConverter getThrowableConverter() {

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/ThreadNameJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/ThreadNameJsonProvider.java
@@ -12,7 +12,7 @@ public class ThreadNameJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
+    protected void writeExactlyOneField(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeStringField(getFieldName(), event.getThreadName());
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/ThreadNameJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/ThreadNameJsonProvider.java
@@ -1,0 +1,20 @@
+package com.github.loki4j.logback.json;
+
+import java.io.IOException;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class ThreadNameJsonProvider extends AbstractFieldJsonProvider {
+
+    public static final String FIELD_THREAD_NAME = "thread_name";
+    
+    public ThreadNameJsonProvider() {
+        setFieldName(FIELD_THREAD_NAME);
+    }
+
+    @Override
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+        writer.writeStringField(getFieldName(), event.getThreadName());
+    }
+    
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/ThreadNameJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/ThreadNameJsonProvider.java
@@ -1,6 +1,5 @@
 package com.github.loki4j.logback.json;
 
-import java.io.IOException;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
@@ -13,7 +12,7 @@ public class ThreadNameJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeStringField(getFieldName(), event.getThreadName());
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/TimestampJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/TimestampJsonProvider.java
@@ -1,0 +1,20 @@
+package com.github.loki4j.logback.json;
+
+import java.io.IOException;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class TimestampJsonProvider extends AbstractFieldJsonProvider {
+
+    public static final String FIELD_TIMESTAMP = "timestamp_ms";
+
+    public TimestampJsonProvider() {
+        setFieldName(FIELD_TIMESTAMP);
+    }
+
+    @Override
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+        writer.writeNumberField(getFieldName(), event.getTimeStamp());
+    }
+    
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/TimestampJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/TimestampJsonProvider.java
@@ -1,7 +1,5 @@
 package com.github.loki4j.logback.json;
 
-import java.io.IOException;
-
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class TimestampJsonProvider extends AbstractFieldJsonProvider {
@@ -13,7 +11,7 @@ public class TimestampJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) throws IOException {
+    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeNumberField(getFieldName(), event.getTimeStamp());
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/TimestampJsonProvider.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/json/TimestampJsonProvider.java
@@ -11,7 +11,7 @@ public class TimestampJsonProvider extends AbstractFieldJsonProvider {
     }
 
     @Override
-    public void writeTo(JsonEventWriter writer, ILoggingEvent event) {
+    protected void writeExactlyOneField(JsonEventWriter writer, ILoggingEvent event) {
         writer.writeNumberField(getFieldName(), event.getTimeStamp());
     }
     

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/AbstractLoki4jEncoderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/AbstractLoki4jEncoderTest.java
@@ -3,6 +3,7 @@ package com.github.loki4j.logback;
 import org.junit.Test;
 
 import com.github.loki4j.slf4j.marker.LabelMarker;
+import com.github.loki4j.testkit.dummy.StringPayload;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/AbstractLoki4jEncoderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/AbstractLoki4jEncoderTest.java
@@ -19,7 +19,7 @@ public class AbstractLoki4jEncoderTest {
     public void testExtractStreamKVPairsIncorrectFormat() {
         withEncoder(toStringEncoder(
                 labelCfg("level=%level,app=\"my\"app", "|", "~", true, false),
-                messageCfg("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
+                plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
                 false,
                 false), encoder -> {
             var kvs1 = encoder.extractStreamKVPairs("level=INFO,app=\"my\"app,test=test");
@@ -32,7 +32,7 @@ public class AbstractLoki4jEncoderTest {
     public void testExtractStreamKVPairsIgnoringEmpty() {
         withEncoder(toStringEncoder(
                 labelCfg(",,level=%level,,app=\"my\"app,", ",", "=", true, false),
-                messageCfg("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
+                plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
                 false,
                 false), encoder -> {
             var kvs1 = encoder.extractStreamKVPairs(",,level=INFO,,app=\"my\"app,test=test,");
@@ -50,7 +50,7 @@ public class AbstractLoki4jEncoderTest {
                     "=",
                     true,
                     false),
-                messageCfg("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
+                plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
                 false,
                 false), encoder -> {
             var kvs1 = encoder.extractStreamKVPairs("\n\n// level is label\nlevel=INFO\n// another comment\n\napp=\"my\"app\n\n// end comment");
@@ -63,7 +63,7 @@ public class AbstractLoki4jEncoderTest {
     public void testExtractStreamKVPairs() {
         withEncoder(toStringEncoder(
                 labelCfg("level=%level,app=\"my\"app", ",", "=", true, false),
-                messageCfg("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
+                plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
                 false,
                 false), encoder -> {
             var kvs1 = encoder.extractStreamKVPairs("level=INFO,app=\"my\"app,test=test");
@@ -73,7 +73,7 @@ public class AbstractLoki4jEncoderTest {
 
         withEncoder(toStringEncoder(
                 labelCfg("level:%level;app:\"my\"app", ";", ":", true, false),
-                messageCfg("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
+                plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
                 false,
                 false), encoder -> {
             var kvs2 = encoder.extractStreamKVPairs("level:INFO;app:\"my\"app;test:test");
@@ -83,7 +83,7 @@ public class AbstractLoki4jEncoderTest {
 
         withEncoder(toStringEncoder(
                 labelCfg("level.%level|app.\"my\"app", "|", ".", true, false),
-                messageCfg("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
+                plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
                 false,
                 false), encoder -> {
             var kvs3 = encoder.extractStreamKVPairs("level.INFO|app.\"my\"app|test.test");
@@ -112,7 +112,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 4,
                 1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, true), messageCfg("%level | %msg"), false, false),
+                toStringEncoder(labelCfg("l=%level", ",", "=", true, true), plainTextMsgLayout("%level | %msg"), false, false),
                 sender), appender -> {
             appender.append(events);
             appender.waitAllAppended();
@@ -149,7 +149,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 6,
                 1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), messageCfg("%level | %msg"), false, true),
+                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), false, true),
                 sender), appender -> {
             appender.append(eventsToOrder);
             appender.waitAllAppended();
@@ -172,7 +172,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 6,
                 1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), messageCfg("%level | %msg"), true, true),
+                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), true, true),
                 sender), appender -> {
             appender.append(eventsToOrder);
             appender.waitAllAppended();
@@ -195,7 +195,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 6,
                 1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), messageCfg("%level | %msg"), false, false),
+                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), false, false),
                 sender), appender -> {
             appender.append(eventsToOrder);
             appender.waitAllAppended();
@@ -221,7 +221,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 6,
                 1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), messageCfg("%level | %msg"), true, false),
+                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), true, false),
                 sender), appender -> {
             appender.append(eventsToOrder);
             appender.waitAllAppended();
@@ -248,7 +248,7 @@ public class AbstractLoki4jEncoderTest {
     public void testNanoCounter() {
         var enc = toStringEncoder(
             labelCfg("app=my-app", ",", "=", true, false),
-            messageCfg("l=%level c=%logger{20} t=%thread | %msg"),
+            plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg"),
             true,
             false);
 

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/ApacheHttpAppenderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/ApacheHttpAppenderTest.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import com.github.loki4j.client.http.HttpHeaders;
 import com.github.loki4j.testkit.dummy.LokiHttpServerMock;
+import com.github.loki4j.testkit.dummy.StringPayload;
 
 import static com.github.loki4j.logback.Generators.*;
 import static com.github.loki4j.logback.Loki4jAppenderTest.*;

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
@@ -113,17 +113,27 @@ public class Generators {
     }
 
     public static JsonEncoder jsonEncoder(boolean staticLabels, String testLabel) {
+        return jsonEncoder(staticLabels, testLabel, null);
+    }
+
+    public static JsonEncoder jsonEncoder(boolean staticLabels, String testLabel, Layout<ILoggingEvent> msgLayout) {
         var encoder = new JsonEncoder();
         encoder.setStaticLabels(staticLabels);
         encoder.setLabel(labelCfg("test=" + testLabel + ",level=%level,app=my-app", ",", "=", true, false));
+        encoder.setMessage(msgLayout);
         encoder.setSortByTime(true);
         return encoder;
     }
 
     public static ProtobufEncoder protobufEncoder(boolean staticLabels, String testLabel) {
+        return protobufEncoder(staticLabels, testLabel, null);
+    }
+
+    public static ProtobufEncoder protobufEncoder(boolean staticLabels, String testLabel, Layout<ILoggingEvent> msgLayout) {
         var encoder = new ProtobufEncoder();
         encoder.setStaticLabels(staticLabels);
         encoder.setLabel(labelCfg("test=" + testLabel + ",level=%level,app=my-app", ",", "=", true, false));
+        encoder.setMessage(msgLayout);
         return encoder;
     }
 

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
@@ -166,7 +166,7 @@ public class Generators {
     public static AbstractLoki4jEncoder wrapToEncoder(
             BiFunction<Integer, ByteBufferFactory, Writer> writerFactory,
             AbstractLoki4jEncoder.LabelCfg label,
-            Layout<ILoggingEvent> message,
+            Layout<ILoggingEvent> messageLayout,
             boolean sortByTime,
             boolean staticLabels) {
         var encoder = new AbstractLoki4jEncoder() {
@@ -176,7 +176,7 @@ public class Generators {
             }
         };
         encoder.setLabel(label);
-        encoder.setMessage(message);
+        encoder.setMessage(messageLayout);
         encoder.setSortByTime(sortByTime);
         encoder.setStaticLabels(staticLabels);
         return encoder;
@@ -184,10 +184,10 @@ public class Generators {
 
     public static AbstractLoki4jEncoder toStringEncoder(
             AbstractLoki4jEncoder.LabelCfg label,
-            Layout<ILoggingEvent> message,
+            Layout<ILoggingEvent> messageLayout,
             boolean sortByTime,
             boolean staticLabels) {
-        return wrapToEncoder(Generators::stringWriter, label, message, sortByTime, staticLabels);
+        return wrapToEncoder(Generators::stringWriter, label, messageLayout, sortByTime, staticLabels);
     }
 
     public static AbstractLoki4jEncoder.LabelCfg labelCfg(

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
@@ -33,9 +33,11 @@ import com.github.loki4j.testkit.dummy.LokiHttpServerMock;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
+import ch.qos.logback.core.Layout;
 
 import static com.github.loki4j.testkit.dummy.Generators.genMessage;
 
@@ -142,7 +144,7 @@ public class Generators {
     public static AbstractLoki4jEncoder defaultToStringEncoder() {
         return toStringEncoder(
             labelCfg("level=%level,app=my-app", ",", "=", true, false),
-            messageCfg("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
+            plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
             true,
             false);
     }
@@ -164,7 +166,7 @@ public class Generators {
     public static AbstractLoki4jEncoder wrapToEncoder(
             BiFunction<Integer, ByteBufferFactory, Writer> writerFactory,
             AbstractLoki4jEncoder.LabelCfg label,
-            AbstractLoki4jEncoder.MessageCfg message,
+            Layout<ILoggingEvent> message,
             boolean sortByTime,
             boolean staticLabels) {
         var encoder = new AbstractLoki4jEncoder() {
@@ -182,7 +184,7 @@ public class Generators {
 
     public static AbstractLoki4jEncoder toStringEncoder(
             AbstractLoki4jEncoder.LabelCfg label,
-            AbstractLoki4jEncoder.MessageCfg message,
+            Layout<ILoggingEvent> message,
             boolean sortByTime,
             boolean staticLabels) {
         return wrapToEncoder(Generators::stringWriter, label, message, sortByTime, staticLabels);
@@ -203,9 +205,8 @@ public class Generators {
         return label;
     }
 
-    public static AbstractLoki4jEncoder.MessageCfg messageCfg(
-            String pattern) {
-        var message = new AbstractLoki4jEncoder.MessageCfg();
+    public static Layout<ILoggingEvent> plainTextMsgLayout(String pattern) {
+        var message = new PatternLayout();
         message.setPattern(pattern);
         return message;
     }

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/JavaHttpAppenderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/JavaHttpAppenderTest.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import com.github.loki4j.client.http.HttpHeaders;
 import com.github.loki4j.testkit.dummy.LokiHttpServerMock;
+import com.github.loki4j.testkit.dummy.StringPayload;
 
 import static com.github.loki4j.logback.Generators.*;
 import static com.github.loki4j.logback.Loki4jAppenderTest.*;

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/JsonLayoutTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/JsonLayoutTest.java
@@ -1,0 +1,106 @@
+package com.github.loki4j.logback;
+
+import static com.github.loki4j.logback.Generators.*;
+import static org.junit.Assert.*;
+
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+import com.github.loki4j.logback.json.AbstractFieldJsonProvider;
+import com.github.loki4j.logback.json.JsonEventWriter;
+import com.github.loki4j.logback.json.JsonProvider;
+import com.github.loki4j.logback.json.LogLevelJsonProvider;
+import com.github.loki4j.logback.json.LoggerNameJsonProvider;
+import com.github.loki4j.logback.json.MessageJsonProvider;
+import com.github.loki4j.logback.json.ThreadNameJsonProvider;
+import com.github.loki4j.logback.json.TimestampJsonProvider;
+import com.github.loki4j.testkit.dummy.StringPayload;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class JsonLayoutTest {
+
+    private static final ILoggingEvent[] events = new ILoggingEvent[] {
+        loggingEvent(100L, Level.INFO, "io.test.TestApp", "main", "m1-line1\r\nline2\r\n", null),
+        loggingEvent(101L, Level.DEBUG, "io.test.TestApp", "thread-1", "m2-line1", null),
+        loggingEvent(102L, Level.WARN, "io.test.TestApp", "main", "m3-line1\nline2\r", null)
+    };
+
+    @Test
+    public void testWorksInAppender() {
+        var expected = StringPayload.builder()
+            .stream("[app, my-app]",
+                "ts=100 {'timestamp_ms':100,'logger_name':'io.test.TestApp','level':'INFO','thread_name':'main','message':'m1-line1\\r\\nline2\\r\\n'}".replace('\'', '"'),
+                "ts=101 {'timestamp_ms':101,'logger_name':'io.test.TestApp','level':'DEBUG','thread_name':'thread-1','message':'m2-line1'}".replace('\'', '"'),
+                "ts=102 {'timestamp_ms':102,'logger_name':'io.test.TestApp','level':'WARN','thread_name':'main','message':'m3-line1\\nline2\\r'}".replace('\'', '"')
+            )
+            .build();
+
+        var encoder = toStringEncoder(
+                labelCfg("app=my-app", ",", "=", true, false),
+                jsonMsgLayout(),
+                false,
+                false
+        );
+        var sender = dummySender();
+        withAppender(appender(3, 1000L, encoder, sender), appender -> {
+            appender.append(events);
+            appender.waitAllAppended();
+
+            var actual = StringPayload.parse(sender.lastBatch(), encoder.charset);
+            //System.out.println(expected);
+            //System.out.println(actual);
+            assertEquals("jsonLayout", expected, actual);
+            return null;
+        });
+    }
+
+    @Test
+    public void testNoEnabledProviders() {
+        var layout = jsonMsgLayout();
+        
+        layout.setLogLevel(disable(LogLevelJsonProvider::new));
+        layout.setLoggerName(disable(LoggerNameJsonProvider::new));
+        layout.setMessage(disable(MessageJsonProvider::new));
+        layout.setThreadName(disable(ThreadNameJsonProvider::new));
+        layout.setTimestamp(disable(TimestampJsonProvider::new));
+        
+        layout.start();
+
+        assertEquals("json empty", "{}", layout.doLayout(events[0]));
+
+        layout.stop();
+    }
+
+    @Test
+    public void testCustomProvider() {
+        var layout = jsonMsgLayout();
+        
+        layout.setLogLevel(disable(LogLevelJsonProvider::new));
+        layout.setLoggerName(disable(LoggerNameJsonProvider::new));
+        layout.setThreadName(disable(ThreadNameJsonProvider::new));
+        layout.setTimestamp(disable(TimestampJsonProvider::new));
+
+        layout.addCustomProvider(new AbstractFieldJsonProvider() {
+            @Override
+            protected void writeExactlyOneField(JsonEventWriter writer, ILoggingEvent event) {
+                writer.writeNumberField("msg_length", Long.valueOf(event.getMessage().length()));
+            }
+        });
+        
+        layout.start();
+
+        assertEquals("custom provider", "{\"message\":\"m2-line1\",\"msg_length\":8}", layout.doLayout(events[1]));
+
+        layout.stop();
+    }
+
+    private <T extends JsonProvider<?>> T disable(Supplier<T> ctor) {
+        var provider = ctor.get();
+        provider.setEnabled(false);
+        return provider;
+    }
+    
+}

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Loki4jAppenderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Loki4jAppenderTest.java
@@ -108,7 +108,7 @@ public class Loki4jAppenderTest {
                     return failingWriter;
                 },
                 labelCfg("level=%level,app=my-app", ",", "=", true, false),
-                messageCfg("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
+                plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
                 true,
                 false);
         var sender = dummySender();

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Loki4jAppenderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Loki4jAppenderTest.java
@@ -1,15 +1,20 @@
 package com.github.loki4j.logback;
 
-import org.junit.Test;
-
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-
+import static com.github.loki4j.logback.Generators.*;
 import static org.junit.Assert.*;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.github.loki4j.logback.Generators.*;
+import org.junit.Test;
+
+import com.github.loki4j.logback.Generators.FailingHttpClient;
+import com.github.loki4j.logback.Generators.FailingStringWriter;
+import com.github.loki4j.logback.Generators.StoppableHttpClient;
+import com.github.loki4j.logback.Generators.WrappingHttpSender;
+import com.github.loki4j.testkit.dummy.StringPayload;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class Loki4jAppenderTest {
 
@@ -151,39 +156,6 @@ public class Loki4jAppenderTest {
 
         appender.stop();
         assertTrue("no batches after stop", sender.lastBatch() == null);
-    }
-
-    @Test
-    public void testEncodeEscapes() {
-        ILoggingEvent[] escEvents = new ILoggingEvent[] {
-            loggingEvent(100L, Level.INFO, "TestApp", "main", "m1-line1\r\nline2\r\n", null),
-            loggingEvent(100L, Level.INFO, "TestApp", "main", "m2-line1\nline2\n", null),
-            loggingEvent(100L, Level.INFO, "TestApp", "main", "m3-line1\rline2\r", null)
-        };
-
-        var encoder = jsonEncoder(false, "testEncodeEscapes");
-        var sender = dummySender();
-        var appender = appender(3, 1000L, encoder, sender);
-        appender.start();
-
-        appender.append(escEvents[0]);
-        appender.append(escEvents[1]);
-        appender.append(escEvents[2]);
-
-        try { Thread.sleep(100L); } catch (InterruptedException e1) { }
-
-        var expected = (
-            "{'streams':[{'stream':{'test':'testEncodeEscapes','level':'INFO','app':'my-app'}," +
-            "'values':[['100100000','l=INFO c=TestApp t=main | m1-line1\\r\\nline2\\r\\n ']," +
-            "['100100001','l=INFO c=TestApp t=main | m2-line1\\nline2\\n ']," +
-            "['100100002','l=INFO c=TestApp t=main | m3-line1\\rline2\\r ']]}]}"
-            ).replace('\'', '"');
-
-        var actual = new String(sender.lastBatch(), encoder.charset);
-        System.out.println(expected);
-        System.out.println(actual);
-        assertEquals("batchSize", expected, actual);
-        appender.stop();
     }
 
     @Test

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/PatternLayoutTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/PatternLayoutTest.java
@@ -1,0 +1,46 @@
+package com.github.loki4j.logback;
+
+import static com.github.loki4j.logback.Generators.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class PatternLayoutTest {
+
+    @Test
+    public void testEncodeEscapes() {
+        ILoggingEvent[] escEvents = new ILoggingEvent[] {
+            loggingEvent(100L, Level.INFO, "TestApp", "main", "m1-line1\r\nline2\r\n", null),
+            loggingEvent(100L, Level.INFO, "TestApp", "main", "m2-line1\nline2\n", null),
+            loggingEvent(100L, Level.INFO, "TestApp", "main", "m3-line1\rline2\r", null)
+        };
+
+        var encoder = jsonEncoder(false, "testEncodeEscapes");
+        var sender = dummySender();
+        var appender = appender(3, 1000L, encoder, sender);
+        appender.start();
+
+        appender.append(escEvents[0]);
+        appender.append(escEvents[1]);
+        appender.append(escEvents[2]);
+
+        try { Thread.sleep(100L); } catch (InterruptedException e1) { }
+
+        var expected = (
+            "{'streams':[{'stream':{'test':'testEncodeEscapes','level':'INFO','app':'my-app'}," +
+            "'values':[['100100000','l=INFO c=TestApp t=main | m1-line1\\r\\nline2\\r\\n ']," +
+            "['100100001','l=INFO c=TestApp t=main | m2-line1\\nline2\\n ']," +
+            "['100100002','l=INFO c=TestApp t=main | m3-line1\\rline2\\r ']]}]}"
+            ).replace('\'', '"');
+
+        var actual = new String(sender.lastBatch(), encoder.charset);
+        //System.out.println(expected);
+        //System.out.println(actual);
+        assertEquals("escape", expected, actual);
+        appender.stop();
+    }
+
+}

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/FastSendTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/FastSendTest.java
@@ -3,6 +3,7 @@ package com.github.loki4j.logback.integration;
 import static com.github.loki4j.logback.Generators.*;
 import static org.junit.Assert.*;
 
+import com.github.loki4j.logback.JsonLayout;
 import com.github.loki4j.testkit.categories.IntegrationTests;
 
 import org.junit.AfterClass;
@@ -46,7 +47,7 @@ public class FastSendTest {
     @Category({IntegrationTests.class})
     public void testJavaJsonFastSend() throws Exception {
         var label = "testJavaJsonFastSend";
-        var encoder = protobufEncoder(false, label);
+        var encoder = jsonEncoder(false, label);
         var sender = javaHttpSender(urlPush);
         var appender = appender(10, 1000, encoder, sender);
 
@@ -70,12 +71,36 @@ public class FastSendTest {
     @Category({IntegrationTests.class})
     public void testJavaProtobufFastSend() throws Exception {
         var label = "testJavaProtobufFastSend";
-        var encoder = jsonEncoder(false, label);
+        var encoder = protobufEncoder(false, label);
         var sender = javaHttpSender(urlPush);
         var appender = appender(10, 1000, encoder, sender);
 
         var events = generateEvents(1000, 10);
         client.testHttpSend(label, events, appender, jsonEncoder(false, label));
+    }
+
+    @Test
+    @Category({IntegrationTests.class})
+    public void testJsonLayoutJsonFastSend() throws Exception {
+        var label = "testJsonLayoutJsonFastSend";
+        var encoder = jsonEncoder(false, label, new JsonLayout());
+        var sender = javaHttpSender(urlPush);
+        var appender = appender(10, 1000, encoder, sender);
+
+        var events = generateEvents(1000, 10);
+        client.testHttpSend(label, events, appender, jsonEncoder(false, label, new JsonLayout()));
+    }
+
+    @Test
+    @Category({IntegrationTests.class})
+    public void testJsonLayoutProtobufFastSend() throws Exception {
+        var label = "testJsonLayoutProtobufFastSend";
+        var encoder = protobufEncoder(false, label, new JsonLayout());
+        var sender = javaHttpSender(urlPush);
+        var appender = appender(10, 1000, encoder, sender);
+
+        var events = generateEvents(1000, 10);
+        client.testHttpSend(label, events, appender, jsonEncoder(false, label, new JsonLayout()));
     }
 
 }

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/GrafanaCloudTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/GrafanaCloudTest.java
@@ -4,6 +4,7 @@ import static com.github.loki4j.logback.Generators.*;
 import static org.junit.Assert.*;
 
 import com.github.loki4j.logback.AbstractHttpSender;
+import com.github.loki4j.logback.JsonLayout;
 import com.github.loki4j.testkit.categories.CIOnlyTests;
 
 import org.junit.AfterClass;
@@ -98,6 +99,30 @@ public class GrafanaCloudTest {
 
         var events = generateEvents(100, 10);
         client.testHttpSend(label, events, appender, jsonEncoder(false, label));
+    }
+
+    @Test
+    @Category({CIOnlyTests.class})
+    public void testJsonLayoutJavaJsonCloud() throws Exception {
+        var label = label("testJsonLayoutJavaJsonCloud");
+        var encoder = jsonEncoder(false, label, new JsonLayout());
+        var sender = authorize(javaHttpSender(urlPush));
+        var appender = appender(10, 1000, encoder, sender);
+
+        var events = generateEvents(20, 10);
+        client.testHttpSend(label, events, appender, jsonEncoder(false, label, new JsonLayout()));
+    }
+
+    @Test
+    @Category({CIOnlyTests.class})
+    public void testJsonLayoutApacheProtobufCloud() throws Exception {
+        var label = label("testJsonLayoutApacheProtobufCloud");
+        var encoder = protobufEncoder(false, label, new JsonLayout());
+        var sender = authorize(apacheHttpSender(urlPush));
+        var appender = appender(10, 1000, encoder, sender);
+
+        var events = generateEvents(50, 10);
+        client.testHttpSend(label, events, appender, jsonEncoder(false, label, new JsonLayout()));
     }
 
     @Test

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/json/LoggerNameJsonProviderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/json/LoggerNameJsonProviderTest.java
@@ -1,0 +1,55 @@
+package com.github.loki4j.logback.json;
+
+import static com.github.loki4j.logback.Generators.loggingEvent;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class LoggerNameJsonProviderTest {
+    
+    private static final ILoggingEvent event = loggingEvent(101L, Level.DEBUG, "io.test.TestApp", "thread-1", "m2-line1", null);
+
+    @Test
+    public void testNoAbbreviation() {
+        var provider = new LoggerNameJsonProvider();
+        provider.start();
+
+        var writer = new JsonEventWriter(0);
+        provider.writeTo(writer, event, false);
+
+        assertEquals("\"logger_name\":\"io.test.TestApp\"", writer.toString());
+
+        provider.stop();
+    }
+
+    @Test
+    public void testClassNameAbbreviation() {
+        var provider = new LoggerNameJsonProvider();
+        provider.setTargetLength(0);
+        provider.start();
+
+        var writer = new JsonEventWriter(0);
+        provider.writeTo(writer, event, false);
+
+        assertEquals("\"logger_name\":\"TestApp\"", writer.toString());
+
+        provider.stop();
+    }
+
+    @Test
+    public void testTargetLengthAbbreviation() {
+        var provider = new LoggerNameJsonProvider();
+        provider.setTargetLength(11);
+        provider.start();
+
+        var writer = new JsonEventWriter(0);
+        provider.writeTo(writer, event, false);
+
+        assertEquals("\"logger_name\":\"i.t.TestApp\"", writer.toString());
+
+        provider.stop();
+    }
+}

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/json/MdcJsonProviderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/json/MdcJsonProviderTest.java
@@ -1,0 +1,88 @@
+package com.github.loki4j.logback.json;
+
+import static com.github.loki4j.logback.Generators.loggingEvent;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import ch.qos.logback.classic.Level;
+
+public class MdcJsonProviderTest {
+    
+    @Test
+    public void testNoMdcInEvent() {
+        var event = loggingEvent(101L, Level.DEBUG, "io.test.TestApp", "thread-1", "m2-line1", null);
+
+        var provider = new MdcJsonProvider();
+        provider.start();
+
+        assertFalse("canWrite", provider.canWrite(event));
+
+        var writer = new JsonEventWriter(0);
+        provider.writeTo(writer, event, false);
+
+        assertEquals("writeTo", "", writer.toString());
+
+        provider.stop();
+    }
+
+    @Test
+    public void testOneMdcInEvent() {
+        var event = loggingEvent(101L, Level.DEBUG, "io.test.TestApp", "thread-1", "m2-line1", null);
+        event.getMDCPropertyMap().put("property1", "value1");
+
+        var provider = new MdcJsonProvider();
+        provider.start();
+
+        assertTrue("canWrite", provider.canWrite(event));
+
+        var writer = new JsonEventWriter(0);
+        provider.writeTo(writer, event, false);
+
+        assertEquals("writeTo", "\"mdc_property1\":\"value1\"", writer.toString());
+
+        provider.stop();
+    }
+
+    @Test
+    public void testExclude() {
+        var event = loggingEvent(101L, Level.DEBUG, "io.test.TestApp", "thread-1", "m2-line1", null);
+        event.getMDCPropertyMap().put("property1", "value1");
+        event.getMDCPropertyMap().put("property2", "value2");
+
+        var provider = new MdcJsonProvider();
+        provider.addExclude("property2");
+        provider.start();
+
+        assertTrue("canWrite", provider.canWrite(event));
+
+        var writer = new JsonEventWriter(0);
+        provider.writeTo(writer, event, false);
+
+        assertEquals("writeTo", "\"mdc_property1\":\"value1\"", writer.toString());
+
+        provider.stop();
+    }
+
+    @Test
+    public void testInclude() {
+        var event = loggingEvent(101L, Level.DEBUG, "io.test.TestApp", "thread-1", "m2-line1", null);
+        event.getMDCPropertyMap().put("property1", "value1");
+        event.getMDCPropertyMap().put("property2", "value2");
+
+        var provider = new MdcJsonProvider();
+        provider.addInclude("property1");
+        provider.start();
+
+        assertTrue("canWrite", provider.canWrite(event));
+
+        var writer = new JsonEventWriter(0);
+        provider.writeTo(writer, event, false);
+
+        assertEquals("writeTo", "\"mdc_property1\":\"value1\"", writer.toString());
+
+        provider.stop();
+    }
+}

--- a/testkit/src/main/java/com/github/loki4j/testkit/dummy/StringPayload.java
+++ b/testkit/src/main/java/com/github/loki4j/testkit/dummy/StringPayload.java
@@ -1,0 +1,82 @@
+package com.github.loki4j.testkit.dummy;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class StringPayload {
+
+    public static final String LABELS_MESSAGE_SEPARATOR = " %%% ";
+
+    public final HashMap<String, ArrayList<String>> data;
+
+    private StringPayload(HashMap<String, ArrayList<String>> data) {
+        this.data = data;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((data == null) ? 0 : data.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        StringPayload other = (StringPayload) obj;
+        if (data == null) {
+            if (other.data != null)
+                return false;
+        } else if (!data.equals(other.data))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "StringPayload [" + data + "]";
+    }
+
+    public static StringPayload parse(String input) {
+        HashMap<String, ArrayList<String>> data = new HashMap<>();
+        var lines = input.split("\n");
+        for (String line : lines) {
+            var pair = line.split(LABELS_MESSAGE_SEPARATOR);
+            var recs = data.computeIfAbsent(pair[0], x -> new ArrayList<>());
+            recs.add(pair[1]);
+        }
+        return new StringPayload(data);
+    }
+
+    public static StringPayload parse(byte[] input) {
+        return parse(new String(input));
+    }
+
+    public static StringPayload parse(byte[] input, Charset charset) {
+        return parse(new String(input, charset));
+    }
+
+    public static StringPayloadBuilder builder() {
+        return new StringPayloadBuilder();
+    }
+
+    public static class StringPayloadBuilder {
+        private HashMap<String, ArrayList<String>> data = new HashMap<>();
+        public StringPayloadBuilder stream(String stream, String... records) {
+            var recs = data.computeIfAbsent(stream, x -> new ArrayList<>());
+            recs.addAll(Arrays.asList(records));
+            return this;
+        }
+        public StringPayload build() {
+            return new StringPayload(data);
+        }
+    }
+}


### PR DESCRIPTION
Refs #167.
Fixes #205.

The design is inspired by logstash-logback-encoder.

If you are eager to test this, you can enable Json layout in the config the following way:

```xml
    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
        <http>
            ...
        </http>
        <format>
            <label>
                ...
            </label>
            <message class="com.github.loki4j.logback.JsonLayout" />
        </format>
    </appender>
```