### PR TITLE
Structured metadata support

### DIFF
--- a/loki-client/src/main/java/com/github/loki4j/client/batch/Batcher.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/batch/Batcher.java
@@ -39,7 +39,10 @@ public final class Batcher {
      * This method is thread-safe.
      */
     public boolean validateLogRecordSize(LogRecord r) {
-        return (r.messageUtf8SizeBytes + 24 + r.stream.utf8SizeBytes + 8) <= maxSizeBytes;
+        var messageSize = r.messageUtf8SizeBytes + 24;
+        var metadataSize = r.metadataUtf8SizeBytes + 24 + r.metadata.length * 2;
+        var streamSize = r.stream.utf8SizeBytes + 8;
+        return messageSize + metadataSize + streamSize <= maxSizeBytes;
     }
 
     /**
@@ -55,6 +58,7 @@ public final class Batcher {
      */
     private long estimateSizeBytes(LogRecord r, boolean dryRun) {
         long size = r.messageUtf8SizeBytes + 24;
+        size += r.metadataUtf8SizeBytes + 24 + r.metadata.length * 2;
         if (!streams.contains(r.stream)) {
             size += r.stream.utf8SizeBytes + 8;
             if (!dryRun) streams.add(r.stream);

--- a/loki-client/src/main/java/com/github/loki4j/client/batch/Batcher.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/batch/Batcher.java
@@ -40,7 +40,7 @@ public final class Batcher {
      */
     public boolean validateLogRecordSize(LogRecord r) {
         var messageSize = r.messageUtf8SizeBytes + 24;
-        var metadataSize = r.metadataUtf8SizeBytes + 24 + r.metadata.length * 2;
+        var metadataSize = r.metadataUtf8SizeBytes + (r.metadata.length == 0 ? 0 : 1) * 24 + r.metadata.length * 2;
         var streamSize = r.stream.utf8SizeBytes + 8;
         return messageSize + metadataSize + streamSize <= maxSizeBytes;
     }
@@ -58,7 +58,7 @@ public final class Batcher {
      */
     private long estimateSizeBytes(LogRecord r, boolean dryRun) {
         long size = r.messageUtf8SizeBytes + 24;
-        size += r.metadataUtf8SizeBytes + 24 + r.metadata.length * 2;
+        size += r.metadataUtf8SizeBytes + (r.metadata.length == 0 ? 0 : 1) * 24 + r.metadata.length * 2;
         if (!streams.contains(r.stream)) {
             size += r.stream.utf8SizeBytes + 8;
             if (!dryRun) streams.add(r.stream);

--- a/loki-client/src/main/java/com/github/loki4j/client/batch/LogRecord.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/batch/LogRecord.java
@@ -1,5 +1,7 @@
 package com.github.loki4j.client.batch;
 
+import java.util.Arrays;
+
 import com.github.loki4j.client.util.StringUtils;
 
 public class LogRecord {
@@ -14,24 +16,37 @@ public class LogRecord {
 
     public final int messageUtf8SizeBytes;
 
+    public final String[] metadata;
+
+    public final int metadataUtf8SizeBytes;
+
     private LogRecord(
             long timestampMs,
             int nanosInMs,
             LogRecordStream stream,
-            String message) {
+            String message,
+            String[] metadata) {
         this.timestampMs = timestampMs;
         this.nanosInMs = nanosInMs;
         this.stream = stream;
         this.message = message;
         this.messageUtf8SizeBytes = StringUtils.utf8Length(message);
+
+        this.metadata = metadata;
+        var metadataUtf8SizeBytes = 0;
+        for (int i = 0; i < metadata.length; i++) {
+            metadataUtf8SizeBytes += StringUtils.utf8Length(metadata[i]);
+        }
+        this.metadataUtf8SizeBytes = metadataUtf8SizeBytes;
     }
 
     public static LogRecord create(
             long timestampMs,
             int nanosInMs,
             LogRecordStream stream,
-            String message) {
-        return new LogRecord(timestampMs, nanosInMs, stream, message);
+            String message,
+            String[] metadata) {
+        return new LogRecord(timestampMs, nanosInMs, stream, message, metadata);
     }
 
     @Override
@@ -39,7 +54,9 @@ public class LogRecord {
         return "LogRecord [ts=" + timestampMs
                 + ", nanos=" + nanosInMs
                 + ", stream=" + stream
-                + ", message=" + message + "]";
+                + ", message=" + message
+                + ", metadata=" + metadata
+                + "]";
     }
 
     @Override
@@ -50,6 +67,7 @@ public class LogRecord {
         result = prime * result + nanosInMs;
         result = prime * result + ((stream == null) ? 0 : stream.hashCode());
         result = prime * result + ((message == null) ? 0 : message.hashCode());
+        result = prime * result + ((metadata == null) ? 0 : metadata.hashCode());
         return result;
     }
 
@@ -75,6 +93,11 @@ public class LogRecord {
             if (other.message != null)
                 return false;
         } else if (!message.equals(other.message))
+            return false;
+        if (metadata == null) {
+            if (other.metadata != null)
+                return false;
+        } else if (!Arrays.equals(metadata, other.metadata))
             return false;
         return true;
     }

--- a/loki-client/src/main/java/com/github/loki4j/client/batch/LogRecord.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/batch/LogRecord.java
@@ -55,7 +55,7 @@ public class LogRecord {
                 + ", nanos=" + nanosInMs
                 + ", stream=" + stream
                 + ", message=" + message
-                + ", metadata=" + metadata
+                + ", metadata=" + Arrays.toString(metadata)
                 + "]";
     }
 

--- a/loki-client/src/main/java/com/github/loki4j/client/pipeline/AsyncBufferPipeline.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/pipeline/AsyncBufferPipeline.java
@@ -177,13 +177,18 @@ public final class AsyncBufferPipeline {
         waitSendQueueLessThan(1, timeoutMs);
     }
 
-    public boolean append(long timestampMs, int nanosInMs, Supplier<LogRecordStream> stream, Supplier<String> message) {
+    public boolean append(
+            long timestampMs,
+            int nanosInMs,
+            Supplier<LogRecordStream> stream,
+            Supplier<String> message,
+            Supplier<String[]> metadata) {
         var startedNs = System.nanoTime();
         boolean accepted = false;
         if (acceptNewEvents.get()) {
             LogRecord record = null;
             try {
-                record = LogRecord.create(timestampMs, nanosInMs, stream.get(), message.get());
+                record = LogRecord.create(timestampMs, nanosInMs, stream.get(), message.get(), metadata.get());
             } catch (Exception e) {
                 log.error(e, "Error occurred while appending an event");
                 if (metrics != null) metrics.appendFailed(() -> e.getClass().getSimpleName());

--- a/loki-client/src/main/java/com/github/loki4j/client/writer/JsonWriter.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/writer/JsonWriter.java
@@ -102,7 +102,23 @@ public final class JsonWriter implements Writer {
         raw.writeQuotedAscii("" + record.timestampMs + nanosToStr(record.nanosInMs));
         raw.writeByte(COMMA);
         raw.writeString(record.message);
+        if (record.metadata.length > 0) {
+            raw.writeByte(COMMA);
+            metadata(record.metadata);
+        }
         raw.writeByte(ARRAY_END);
+    }
+
+    private void metadata(String[] metadata) {
+        raw.writeByte(OBJECT_START);
+        for (int i = 0; i < metadata.length; i+=2) {
+            raw.writeString(metadata[i]);
+            raw.writeByte(SEMI);
+            raw.writeString(metadata[i + 1]);
+            if (i < metadata.length - 2)
+                raw.writeByte(COMMA);
+        }
+        raw.writeByte(OBJECT_END);
     }
 
     private String nanosToStr(int nanos) {

--- a/loki-client/src/test/java/com/github/loki4j/client/batch/BatcherTest.java
+++ b/loki-client/src/test/java/com/github/loki4j/client/batch/BatcherTest.java
@@ -5,12 +5,14 @@ import static org.junit.Assert.*;
 
 public class BatcherTest {
 
+    private static String[] EMPTY_METADATA = new String[0];
+
     private static LogRecord logRecord(long ts) {
-        return LogRecord.create(ts, 0, LogRecordStream.create("testkey", "testval"), ("message" + ts));
+        return LogRecord.create(ts, 0, LogRecordStream.create("testkey", "testval"), ("message" + ts), EMPTY_METADATA);
     }
 
     private static LogRecord logRecord(long ts, LogRecordStream stream, String message) {
-        return LogRecord.create(ts, 0, stream, message);
+        return LogRecord.create(ts, 0, stream, message, EMPTY_METADATA);
     }
 
     @Test 

--- a/loki-client/src/test/java/com/github/loki4j/client/writer/ProtobufWriterTest.java
+++ b/loki-client/src/test/java/com/github/loki4j/client/writer/ProtobufWriterTest.java
@@ -13,6 +13,7 @@ import com.github.loki4j.client.batch.LogRecordStream;
 import com.github.loki4j.client.util.ByteBufferFactory;
 import com.github.loki4j.pkg.google.protobuf.Timestamp;
 import com.github.loki4j.pkg.loki.protobuf.Push.EntryAdapter;
+import com.github.loki4j.pkg.loki.protobuf.Push.LabelPairAdapter;
 import com.github.loki4j.pkg.loki.protobuf.Push.PushRequest;
 import com.github.loki4j.pkg.loki.protobuf.Push.StreamAdapter;
 
@@ -20,11 +21,12 @@ public class ProtobufWriterTest {
 
     private LogRecordStream stream1 = LogRecordStream.create("level", "INFO", "app", "my-app");
     private LogRecordStream stream2 = LogRecordStream.create("level", "DEBUG", "app", "my-app");
+    private String[] emptyMetadata = new String[0];
     private LogRecordBatch batch = new LogRecordBatch(new LogRecord[] {
-        LogRecord.create(3000, 1, stream2, "l=DEBUG c=test.TestApp t=thread-2 | Test message 2"),
-        LogRecord.create(1000, 2, stream1, "l=INFO c=test.TestApp t=thread-1 | Test message 1"),
-        LogRecord.create(2000, 3, stream1, "l=INFO c=test.TestApp t=thread-3 | Test message 4"),
-        LogRecord.create(5000, 4, stream1, "l=INFO c=test.TestApp t=thread-1 | Test message 3"),
+        LogRecord.create(3000, 1, stream2, "l=DEBUG c=test.TestApp t=thread-2 | Test message 2", emptyMetadata),
+        LogRecord.create(1000, 2, stream1, "l=INFO c=test.TestApp t=thread-1 | Test message 1", emptyMetadata),
+        LogRecord.create(2000, 3, stream1, "l=INFO c=test.TestApp t=thread-3 | Test message 4", emptyMetadata),
+        LogRecord.create(5000, 4, stream1, "l=INFO c=test.TestApp t=thread-1 | Test message 3", emptyMetadata),
     });
 
     private PushRequest expectedPushRequest = PushRequest.newBuilder()
@@ -32,18 +34,24 @@ public class ProtobufWriterTest {
             .setLabels("{level=\"DEBUG\",app=\"my-app\"}")
             .addEntries(EntryAdapter.newBuilder()
                 .setTimestamp(Timestamp.newBuilder().setSeconds(3).setNanos(1))
-                .setLine("l=DEBUG c=test.TestApp t=thread-2 | Test message 2")))
+                .setLine("l=DEBUG c=test.TestApp t=thread-2 | Test message 2")
+            )
+        )
         .addStreams(StreamAdapter.newBuilder()
             .setLabels("{level=\"INFO\",app=\"my-app\"}")
             .addEntries(EntryAdapter.newBuilder()
                 .setTimestamp(Timestamp.newBuilder().setSeconds(1).setNanos(2))
-                .setLine("l=INFO c=test.TestApp t=thread-1 | Test message 1"))
+                .setLine("l=INFO c=test.TestApp t=thread-1 | Test message 1")
+            )
             .addEntries(EntryAdapter.newBuilder()
                 .setTimestamp(Timestamp.newBuilder().setSeconds(2).setNanos(3))
-                .setLine("l=INFO c=test.TestApp t=thread-3 | Test message 4"))
+                .setLine("l=INFO c=test.TestApp t=thread-3 | Test message 4")
+            )
             .addEntries(EntryAdapter.newBuilder()
                 .setTimestamp(Timestamp.newBuilder().setSeconds(5).setNanos(4))
-                .setLine("l=INFO c=test.TestApp t=thread-1 | Test message 3")))
+                .setLine("l=INFO c=test.TestApp t=thread-1 | Test message 3")
+            )
+        )
         .build();
 
     @Test
@@ -82,6 +90,49 @@ public class ProtobufWriterTest {
         var actUncomp = Snappy.uncompress(actComp);
         assertArrayEquals("un-compressed messages match", expUncomp, actUncomp);
         assertEquals("deserialized", expectedPushRequest, PushRequest.parseFrom(actUncomp));
+    }
+
+    public void testStructuredMetadata() throws IOException {
+        String[] metadata1 = new String[] { "cluster", "clusterA", "traceId", "A00001" };
+        String[] metadata2 = new String[] { "cluster", "clusterB", "traceId", "B56762" };
+        LogRecordBatch metaBatch = new LogRecordBatch(new LogRecord[] {
+            LogRecord.create(2000, 3, stream1, "l=INFO c=test.TestApp t=thread-3 | Test message 4", metadata1),
+            LogRecord.create(5000, 4, stream1, "l=INFO c=test.TestApp t=thread-1 | Test message 3", metadata2),
+        });
+
+        PushRequest expectedMetaPushRequest = PushRequest.newBuilder()
+            .addStreams(StreamAdapter.newBuilder()
+                .setLabels("{level=\"INFO\",app=\"my-app\"}")
+                .addEntries(EntryAdapter.newBuilder()
+                    .setTimestamp(Timestamp.newBuilder().setSeconds(2).setNanos(3))
+                    .setLine("l=INFO c=test.TestApp t=thread-3 | Test message 4")
+                    .addStructuredMetadata(LabelPairAdapter.newBuilder().setName("cluster").setValue("clusterA"))
+                    .addStructuredMetadata(LabelPairAdapter.newBuilder().setName("traceId").setValue("A00001"))
+                )
+                .addEntries(EntryAdapter.newBuilder()
+                    .setTimestamp(Timestamp.newBuilder().setSeconds(5).setNanos(4))
+                    .setLine("l=INFO c=test.TestApp t=thread-1 | Test message 3")
+                    .addStructuredMetadata(LabelPairAdapter.newBuilder().setName("cluster").setValue("clusterB"))
+                    .addStructuredMetadata(LabelPairAdapter.newBuilder().setName("traceId").setValue("B56762"))
+                )
+            )
+            .build();
+
+        var expUncomp = expectedMetaPushRequest.toByteArray();
+        var expComp = Snappy.compress(expUncomp);
+
+        var writer = new ProtobufWriter(1000, new ByteBufferFactory(false));
+        assertEquals("initial size is 0", 0, writer.size());
+        writer.serializeBatch(metaBatch);
+        assertEquals("size is correct", expComp.length, writer.size());
+
+        var actComp = writer.toByteArray();
+        assertEquals("size reset", 0, writer.size());
+        assertArrayEquals("compressed messages match", expComp, actComp);
+
+        var actUncomp = Snappy.uncompress(actComp);
+        assertArrayEquals("un-compressed messages match", expUncomp, actUncomp);
+        assertEquals("deserialized", expectedMetaPushRequest, PushRequest.parseFrom(actUncomp));
     }
     
 }

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/Loki4jAppender.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/Loki4jAppender.java
@@ -198,7 +198,8 @@ public class Loki4jAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             event.getTimeStamp(),
             event.getNanoseconds() % 1_000_000, // take only nanos, not ms
             () -> encoder.eventToStream(event),
-            () -> encoder.eventToMessage(event));
+            () -> encoder.eventToMessage(event),
+            () -> encoder.eventToMetadata(event));
 
         if (!appended)
             reportDroppedEvents();

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/Loki4jEncoder.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/Loki4jEncoder.java
@@ -16,6 +16,8 @@ public interface Loki4jEncoder extends ContextAware, LifeCycle {
 
     String eventToMessage(ILoggingEvent e);
 
+    String[] eventToMetadata(ILoggingEvent e);
+
     WriterFactory getWriterFactory();
 
     boolean getSortByTime();

--- a/loki-logback-appender/src/main/java/com/github/loki4j/slf4j/marker/AbstractKeyValueMarker.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/slf4j/marker/AbstractKeyValueMarker.java
@@ -1,0 +1,76 @@
+package com.github.loki4j.slf4j.marker;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import org.slf4j.Marker;
+
+/*
+ * An abstract SLF4J marker carrying a set of key-value pairs
+ */
+public abstract class AbstractKeyValueMarker implements Marker {
+
+    private final Supplier<Map<String, String>> kvSupplier;
+
+    private final AtomicReference<Map<String, String>> kvValue = new AtomicReference<>(null);
+
+    public AbstractKeyValueMarker(Supplier<Map<String, String>> kvSupplier) {
+        if (kvSupplier == null)
+            throw new IllegalArgumentException("Labels can not be null");
+
+        this.kvSupplier = kvSupplier;
+    }
+
+    public Map<String, String> getKeyValuePairs() {
+        kvValue.compareAndSet(null, kvSupplier.get());
+        return kvValue.get();
+    }
+
+    @Override
+    public void add(Marker reference) {
+        throw new UnsupportedOperationException("LabelMarker does not support adding references");
+    }
+
+    @Override
+    public boolean remove(Marker reference) {
+        return false;
+    }
+
+    @Override
+    public boolean hasChildren() {
+        return false;
+    }
+
+    @Override
+    public boolean hasReferences() {
+        return false;
+    }
+
+    @Override
+    public Iterator<Marker> iterator() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public boolean contains(Marker other) {
+        return false;
+    }
+
+    @Override
+    public boolean contains(String name) {
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+}

--- a/loki-logback-appender/src/main/java/com/github/loki4j/slf4j/marker/LabelMarker.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/slf4j/marker/LabelMarker.java
@@ -24,8 +24,8 @@ public class LabelMarker extends AbstractKeyValueMarker {
      * Creates a Marker containing a set of Loki labels, where each label is a key-value pair.
      * @param labels Labels will be created at time when they are first accessed (i.e. deferred creation).
      */
-    public static StructuredMetadataMarker of(Supplier<Map<String, String>> labels) {
-        return new StructuredMetadataMarker(labels);
+    public static LabelMarker of(Supplier<Map<String, String>> labels) {
+        return new LabelMarker(labels);
     }
 
     /**
@@ -33,7 +33,7 @@ public class LabelMarker extends AbstractKeyValueMarker {
      * @param key Key of the label (assumed to be static).
      * @param value Value od the label will be created at time when it is first accessed (i.e. deferred creation).
      */
-    public static StructuredMetadataMarker of(String key, Supplier<String> value) {
+    public static LabelMarker of(String key, Supplier<String> value) {
         return of(() -> Collections.singletonMap(key, value.get()));
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/slf4j/marker/LabelMarker.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/slf4j/marker/LabelMarker.java
@@ -1,29 +1,18 @@
 package com.github.loki4j.slf4j.marker;
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-
-import org.slf4j.Marker;
 
 /*
  * A SLF4J Marker implementation that allows to dynamically add Loki labels to the log record.
  */
-public class LabelMarker implements Marker {
+public class LabelMarker extends AbstractKeyValueMarker {
 
     private static final String name = "LOKI4J_LABEL_MARKER";
 
-    private final Supplier<Map<String, String>> labelsSupplier;
-
-    private final AtomicReference<Map<String, String>> labelsValue = new AtomicReference<>(null);
-
     public LabelMarker(Supplier<Map<String, String>> labelsSupplier) {
-        if (labelsSupplier == null)
-            throw new IllegalArgumentException("Labels can not be null");
-
-        this.labelsSupplier = labelsSupplier;
+        super(labelsSupplier);
     }
 
     @Override
@@ -31,62 +20,12 @@ public class LabelMarker implements Marker {
         return name;
     }
 
-    public Map<String, String> getLabels() {
-        labelsValue.compareAndSet(null, labelsSupplier.get());
-        return labelsValue.get();
-    }
-
-    @Override
-    public void add(Marker reference) {
-        throw new UnsupportedOperationException("LabelMarker does not support adding references");
-    }
-
-    @Override
-    public boolean remove(Marker reference) {
-        return false;
-    }
-
-    @Override
-    public boolean hasChildren() {
-        return false;
-    }
-
-    @Override
-    public boolean hasReferences() {
-        return false;
-    }
-
-    @Override
-    public Iterator<Marker> iterator() {
-        return Collections.emptyIterator();
-    }
-
-    @Override
-    public boolean contains(Marker other) {
-        return false;
-    }
-
-    @Override
-    public boolean contains(String name) {
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return System.identityHashCode(this);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return this == obj;
-    }
-
     /**
      * Creates a Marker containing a set of Loki labels, where each label is a key-value pair.
      * @param labels Labels will be created at time when they are first accessed (i.e. deferred creation).
      */
-    public static LabelMarker of(Supplier<Map<String, String>> labels) {
-        return new LabelMarker(labels);
+    public static StructuredMetadataMarker of(Supplier<Map<String, String>> labels) {
+        return new StructuredMetadataMarker(labels);
     }
 
     /**
@@ -94,7 +33,7 @@ public class LabelMarker implements Marker {
      * @param key Key of the label (assumed to be static).
      * @param value Value od the label will be created at time when it is first accessed (i.e. deferred creation).
      */
-    public static LabelMarker of(String key, Supplier<String> value) {
+    public static StructuredMetadataMarker of(String key, Supplier<String> value) {
         return of(() -> Collections.singletonMap(key, value.get()));
     }
     

--- a/loki-logback-appender/src/main/java/com/github/loki4j/slf4j/marker/StructuredMetadataMarker.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/slf4j/marker/StructuredMetadataMarker.java
@@ -1,0 +1,40 @@
+package com.github.loki4j.slf4j.marker;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/*
+ * A SLF4J Marker implementation that allows to dynamically add structured metadata to the log record.
+ */
+public class StructuredMetadataMarker extends AbstractKeyValueMarker {
+
+    private static final String name = "LOKI4J_LABEL_MARKER";
+
+    public StructuredMetadataMarker(Supplier<Map<String, String>> metadata) {
+        super(metadata);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Creates a Marker containing a set of key-value pairs, passed to Loki as structured metadata.
+     * @param metadata Key-value pairs will be created at time when they are first accessed (i.e. deferred creation).
+     */
+    public static StructuredMetadataMarker of(Supplier<Map<String, String>> metadata) {
+        return new StructuredMetadataMarker(metadata);
+    }
+
+    /**
+     * Creates a Marker containing a key-value pair, passed to Loki as structured metadata.
+     * @param key Key of the label (assumed to be static).
+     * @param value Value od the label will be created at time when it is first accessed (i.e. deferred creation).
+     */
+    public static StructuredMetadataMarker of(String key, Supplier<String> value) {
+        return of(() -> Collections.singletonMap(key, value.get()));
+    }
+    
+}

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
@@ -51,6 +52,8 @@ public class Generators {
             var r = batch.get(i);
             s
                 .append(Arrays.toString(r.stream.labels))
+                .append(StringPayload.LABELS_MESSAGE_SEPARATOR)
+                .append(Arrays.toString(r.metadata))
                 .append(StringPayload.LABELS_MESSAGE_SEPARATOR)
                 .append("ts=")
                 .append(r.timestampMs)
@@ -213,6 +216,17 @@ public class Generators {
         return label;
     }
 
+    public static AbstractLoki4jEncoder.LabelCfg labelMetadataCfg(
+            String pattern,
+            String metadataPattern,
+            boolean readMarkers) {
+        var label = new AbstractLoki4jEncoder.LabelCfg();
+        label.setPattern(pattern);
+        label.setStructuredMetadataPattern(metadataPattern);
+        label.setReadMarkers(readMarkers);
+        return label;
+    }
+
     public static PatternLayout plainTextMsgLayout(String pattern) {
         var message = new PatternLayout();
         message.setPattern(pattern);
@@ -275,7 +289,7 @@ public class Generators {
             String threadName,
             String message,
             Throwable throwable,
-            Marker marker) {
+            List<Marker> markers) {
         var e = new LoggingEvent();
         e.setTimeStamp(timestamp);
         e.setLevel(level);
@@ -285,8 +299,8 @@ public class Generators {
         e.setMDCPropertyMap(new HashMap<>());
         if (throwable != null)
             e.setThrowableProxy(new ThrowableProxy(throwable));
-        if (marker != null)
-            e.addMarker(marker);
+        if (markers != null)
+            markers.forEach(e::addMarker);
         return e;
     }
 

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
@@ -48,14 +48,14 @@ public class Generators {
     public static String batchToString(LogRecordBatch batch) {
         var s = new StringBuilder();
         for (int i = 0; i < batch.size(); i++) {
-            var b = batch.get(i);
+            var r = batch.get(i);
             s
-                .append(Arrays.toString(b.stream.labels))
+                .append(Arrays.toString(r.stream.labels))
                 .append(StringPayload.LABELS_MESSAGE_SEPARATOR)
                 .append("ts=")
-                .append(b.timestampMs)
+                .append(r.timestampMs)
                 .append(" ")
-                .append(b.message)
+                .append(r.message)
                 .append('\n');
         }
         return s.toString();
@@ -305,7 +305,8 @@ public class Generators {
             e.getTimeStamp(),
             0,
             enc.eventToStream(e),
-            enc.eventToMessage(e));
+            enc.eventToMessage(e),
+            enc.eventToMetadata(e));
     }
 
     public static class AppenderWrapper {

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Loki4jAppenderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Loki4jAppenderTest.java
@@ -10,9 +10,9 @@ import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 
-import com.github.loki4j.logback.Generators.FailingStringWriter;
 import com.github.loki4j.logback.Generators.WrappingHttpSender;
 import com.github.loki4j.testkit.dummy.FailingHttpClient;
+import com.github.loki4j.testkit.dummy.FailingStringWriter;
 import com.github.loki4j.testkit.dummy.StringPayload;
 import com.github.loki4j.testkit.dummy.SuspendableHttpClient;
 import com.github.loki4j.testkit.dummy.FailingHttpClient.FailureType;

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/LokiTestingClient.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/integration/LokiTestingClient.java
@@ -145,7 +145,8 @@ public class LokiTestingClient {
                     events[i].getTimeStamp(),
                     events[i].getNanoseconds() % 1_000_000,
                     encoder.eventToStream(events[idx]),
-                    encoder.eventToMessage(events[idx]));
+                    encoder.eventToMessage(events[idx]),
+                    encoder.eventToMetadata(events[idx]));
             }
             var batch = new LogRecordBatch(records);
             batch.sort(lokiLogsSorting);

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/performance/BatchBufferTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/performance/BatchBufferTest.java
@@ -22,12 +22,15 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class BatchBufferTest {
 
+    private static final String[] EMPTY_METADATA = new String[0];
+
     public static LogRecord eventToRecord(ILoggingEvent e) {
         return LogRecord.create(
             e.getTimeStamp(),
             0,
             LogRecordStream.create("test","dlkjafh"),
-            e.getMessage());
+            e.getMessage(),
+            EMPTY_METADATA);
     }
 
     @Test

--- a/testkit/src/main/java/com/github/loki4j/testkit/dummy/FailingStringWriter.java
+++ b/testkit/src/main/java/com/github/loki4j/testkit/dummy/FailingStringWriter.java
@@ -1,0 +1,21 @@
+package com.github.loki4j.testkit.dummy;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.github.loki4j.client.batch.LogRecordBatch;
+import com.github.loki4j.client.util.ByteBufferFactory;
+
+public class FailingStringWriter extends StringWriter {
+    public AtomicBoolean fail = new AtomicBoolean(false);
+
+    public FailingStringWriter(int capacity, ByteBufferFactory bufferFactory) {
+        super(capacity, bufferFactory);
+    }
+
+    @Override
+    public void serializeBatch(LogRecordBatch batch) {
+        if (fail.get())
+            throw new RuntimeException("Text exception");
+        super.serializeBatch(batch);
+    }
+}

--- a/testkit/src/main/java/com/github/loki4j/testkit/dummy/StringPayload.java
+++ b/testkit/src/main/java/com/github/loki4j/testkit/dummy/StringPayload.java
@@ -4,6 +4,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.stream.Collectors;
 
 public class StringPayload {
 
@@ -73,7 +74,10 @@ public class StringPayload {
         private HashMap<String, ArrayList<StringLogRecord>> data = new HashMap<>();
         public StringPayloadBuilder stream(String stream, String... records) {
             var recs = data.computeIfAbsent(stream, x -> new ArrayList<>());
-            recs.addAll(Arrays.asList(records).stream().map(r -> new StringLogRecord(Arrays.toString(EMPTY), r)).toList());
+            recs.addAll(Arrays.asList(records).stream()
+                    .map(r -> new StringLogRecord(Arrays.toString(EMPTY), r))
+                    .collect(Collectors.toList())
+            );
             return this;
         }
         public StringPayloadBuilder streamWithMeta(String stream, StringLogRecord... records) {

--- a/testkit/src/main/java/com/github/loki4j/testkit/dummy/StringWriter.java
+++ b/testkit/src/main/java/com/github/loki4j/testkit/dummy/StringWriter.java
@@ -1,0 +1,80 @@
+package com.github.loki4j.testkit.dummy;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import java.util.Arrays;
+
+import com.github.loki4j.client.batch.LogRecordBatch;
+import com.github.loki4j.client.util.ByteBufferFactory;
+import com.github.loki4j.client.writer.Writer;
+
+public class StringWriter implements Writer {
+    private final ByteBufferFactory bf;
+    private ByteBuffer b;
+    private int size = 0;
+
+    public StringWriter(int capacity, ByteBufferFactory bufferFactory) {
+        bf = bufferFactory;
+        b = bf.allocate(capacity);
+    }
+
+    public static String batchToString(LogRecordBatch batch) {
+        var s = new StringBuilder();
+        for (int i = 0; i < batch.size(); i++) {
+            var r = batch.get(i);
+            s
+                .append(Arrays.toString(r.stream.labels))
+                .append(StringPayload.LABELS_MESSAGE_SEPARATOR)
+                .append(Arrays.toString(r.metadata))
+                .append(StringPayload.LABELS_MESSAGE_SEPARATOR)
+                .append("ts=")
+                .append(r.timestampMs)
+                .append(" ")
+                .append(r.message)
+                .append('\n');
+        }
+        return s.toString();
+    }
+
+    @Override
+    public void serializeBatch(LogRecordBatch batch) {
+        b.clear();
+        var str = batchToString(batch);
+        var data = str.getBytes(StandardCharsets.UTF_8);
+        if (b.capacity() < data.length)
+            b = bf.allocate(data.length);
+        b.put(data);
+        b.flip();
+        size = data.length;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public void toByteBuffer(ByteBuffer buffer) {
+        buffer.put(b);
+        buffer.flip();
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        byte[] r = new byte[b.remaining()];
+        b.get(r);
+        return r;
+    }
+
+    @Override
+    public void reset() {
+        size = 0;
+        b.clear();
+    }
+
+    @Override
+    public boolean isBinary() {
+        return false;
+    }
+}


### PR DESCRIPTION
Fixes #225

Excerpt from [Loki docs](https://grafana.com/docs/loki/latest/reference/loki-http-api/#ingest-logs):

> The JSON object must be a valid JSON object with string keys and string values. The JSON object should not contain any nested object.