### PR TITLE
Drop sorting log records by time

### DIFF
--- a/loki-client/src/main/java/com/github/loki4j/client/pipeline/PipelineConfig.java
+++ b/loki-client/src/main/java/com/github/loki4j/client/pipeline/PipelineConfig.java
@@ -65,13 +65,6 @@ public class PipelineConfig {
     public final long batchTimeoutMs;
 
     /**
-     * If true, log records in batch are sorted by timestamp.
-     * If false, records will be sent to Loki in arrival order.
-     * Turn this on if you see 'entry out of order' error from Loki.
-     */
-    public final boolean sortByTime;
-
-    /**
      * If you use only one label for all log records, you can
      * set this flag to true and save some CPU time on grouping records by label.
      */
@@ -162,7 +155,6 @@ public class PipelineConfig {
             int batchMaxItems,
             int batchMaxBytes,
             long batchTimeoutMs,
-            boolean sortByTime,
             boolean staticLabels,
             long sendQueueMaxBytes,
             int maxRetries,
@@ -181,7 +173,6 @@ public class PipelineConfig {
         this.batchMaxItems = batchMaxItems;
         this.batchMaxBytes = batchMaxBytes;
         this.batchTimeoutMs = batchTimeoutMs;
-        this.sortByTime = sortByTime;
         this.staticLabels = staticLabels;
         this.sendQueueMaxBytes = sendQueueMaxBytes;
         this.maxRetries = maxRetries;
@@ -209,7 +200,6 @@ public class PipelineConfig {
         private int batchMaxItems = 1000;
         private int batchMaxBytes = 4 * 1024 * 1024;
         private long batchTimeoutMs = 60 * 1000;
-        private boolean sortByTime = false;
         private boolean staticLabels = false;
         private long sendQueueMaxBytes = batchMaxBytes * 10;
         private int maxRetries = 2;
@@ -232,7 +222,6 @@ public class PipelineConfig {
                     batchMaxItems,
                     batchMaxBytes,
                     batchTimeoutMs,
-                    sortByTime,
                     staticLabels,
                     sendQueueMaxBytes,
                     maxRetries,
@@ -267,11 +256,6 @@ public class PipelineConfig {
 
         public Builder setBatchTimeoutMs(long batchTimeoutMs) {
             this.batchTimeoutMs = batchTimeoutMs;
-            return this;
-        }
-
-        public Builder setSortByTime(boolean sortByTime) {
-            this.sortByTime = sortByTime;
             return this;
         }
 

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/AbstractLoki4jEncoder.java
@@ -92,13 +92,6 @@ public abstract class AbstractLoki4jEncoder extends ContextAwareBase implements 
     private LabelCfg label = new LabelCfg();
 
     /**
-     * If true, log records in batch are sorted by timestamp.
-     * If false, records will be sent to Loki in arrival order.
-     * Turn this on if you see 'entry out of order' error from Loki.
-     */
-    private boolean sortByTime = false;
-
-    /**
      * If you use only one label for all log records, you can
      * set this flag to true and save some CPU time on grouping records by label.
      */
@@ -291,13 +284,6 @@ public abstract class AbstractLoki4jEncoder extends ContextAwareBase implements 
     @DefaultClass(PatternLayout.class)
     public void setMessage(Layout<ILoggingEvent> message) {
         this.messageLayout = message;
-    }
-
-    public boolean getSortByTime() {
-        return sortByTime;
-    }
-    public void setSortByTime(boolean sortByTime) {
-        this.sortByTime = sortByTime;
     }
 
     public boolean getStaticLabels() {

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/Loki4jAppender.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/Loki4jAppender.java
@@ -151,7 +151,6 @@ public class Loki4jAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             .setBatchMaxItems(batchMaxItems)
             .setBatchMaxBytes(batchMaxBytes)
             .setBatchTimeoutMs(batchTimeoutMs)
-            .setSortByTime(encoder.getSortByTime())
             .setStaticLabels(encoder.getStaticLabels())
             .setSendQueueMaxBytes(sendQueueMaxBytes)
             .setMaxRetries(maxRetries)

--- a/loki-logback-appender/src/main/java/com/github/loki4j/logback/Loki4jEncoder.java
+++ b/loki-logback-appender/src/main/java/com/github/loki4j/logback/Loki4jEncoder.java
@@ -20,8 +20,6 @@ public interface Loki4jEncoder extends ContextAware, LifeCycle {
 
     WriterFactory getWriterFactory();
 
-    boolean getSortByTime();
-
     boolean getStaticLabels();
 
 }

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/AbstractLoki4jEncoderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/AbstractLoki4jEncoderTest.java
@@ -79,7 +79,6 @@ public class AbstractLoki4jEncoderTest {
         var encoder1 = toStringEncoder(
                 labelCfg("level=%level,app=", ",", "=", true, false),
                 plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
-                true,
                 false);
         var sender = dummySender();
         assertThrows("KV separation failed", IllegalArgumentException.class, () ->
@@ -91,7 +90,6 @@ public class AbstractLoki4jEncoderTest {
         var encoder2 = toStringEncoder(
                 labelCfg("level=%lev{,app=x", ",", "=", true, false),
                 plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
-                true,
                 false);
                 assertThrows("Converter parsing failed", IllegalArgumentException.class, () ->
         withAppender(appender(30, 400L, encoder2, sender), appender -> {
@@ -106,7 +104,6 @@ public class AbstractLoki4jEncoderTest {
         var encoder = toStringEncoder(
                 labelCfg("level=%level,app=my-app,thread=%thread", ",", "=", true, false),
                 plainTextMsgLayout("l=%level | %msg %ex{1}"),
-                true,
                 false);
         encoder.setContext(new LoggerContext());
         encoder.start();
@@ -131,7 +128,6 @@ public class AbstractLoki4jEncoderTest {
         var encoder = toStringEncoder(
                 labelCfg("level=%level.class=%logger.thread=%thread", ".", "=", true, false),
                 plainTextMsgLayout("l=%level | %msg %ex{1}"),
-                true,
                 false);
         encoder.setContext(new LoggerContext());
         encoder.start();
@@ -162,7 +158,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 4,
                 1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, true), plainTextMsgLayout("%level | %msg"), false, false),
+                toStringEncoder(labelCfg("l=%level", ",", "=", true, true), plainTextMsgLayout("%level | %msg"), false),
                 sender), appender -> {
             appender.append(events);
             appender.waitAllAppended();
@@ -200,7 +196,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 4,
                 1000L,
-                toStringEncoder(labelMetadataCfg("l=%level", "t=%thread,c=%logger", true), plainTextMsgLayout("%level | %msg"), false, false),
+                toStringEncoder(labelMetadataCfg("l=%level", "t=%thread,c=%logger", true), plainTextMsgLayout("%level | %msg"), false),
                 sender), appender -> {
             appender.append(events);
             appender.waitAllAppended();
@@ -233,7 +229,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 4,
                 1000L,
-                toStringEncoder(labelMetadataCfg("l=%level", "t=%thread,c=%logger", true), plainTextMsgLayout("%level | %msg"), false, false),
+                toStringEncoder(labelMetadataCfg("l=%level", "t=%thread,c=%logger", true), plainTextMsgLayout("%level | %msg"), false),
                 sender), appender -> {
             appender.append(events);
             appender.waitAllAppended();
@@ -265,7 +261,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 6,
                 1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), false, true),
+                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), true),
                 sender), appender -> {
             appender.append(eventsToOrder);
             appender.waitAllAppended();
@@ -288,30 +284,7 @@ public class AbstractLoki4jEncoderTest {
             appender(
                 6,
                 1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), true, true),
-                sender), appender -> {
-            appender.append(eventsToOrder);
-            appender.waitAllAppended();
-            assertEquals(
-                "static labels, sort by time",
-                StringPayload.builder()
-                    .stream("[l, INFO]",
-                        "ts=100 INFO | Test message 3",
-                        "ts=103 DEBUG | Test message 2",
-                        "ts=103 ERROR | Test message 5",
-                        "ts=104 WARN | Test message 4",
-                        "ts=105 INFO | Test message 1",
-                        "ts=110 INFO | Test message 6")
-                    .build(),
-                StringPayload.parse(sender.lastSendData()));
-            return null;
-        });
-
-        withAppender(
-            appender(
-                6,
-                1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), false, false),
+                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), false),
                 sender), appender -> {
             appender.append(eventsToOrder);
             appender.waitAllAppended();
@@ -321,32 +294,6 @@ public class AbstractLoki4jEncoderTest {
                     .stream("[l, INFO]",
                         "ts=105 INFO | Test message 1",
                         "ts=100 INFO | Test message 3",
-                        "ts=110 INFO | Test message 6")
-                    .stream("[l, DEBUG]",
-                        "ts=103 DEBUG | Test message 2")
-                    .stream("[l, WARN]",
-                        "ts=104 WARN | Test message 4")
-                    .stream("[l, ERROR]",
-                        "ts=103 ERROR | Test message 5")
-                    .build(),
-                StringPayload.parse(sender.lastSendData()));
-            return null;
-        });
-
-        withAppender(
-            appender(
-                6,
-                1000L,
-                toStringEncoder(labelCfg("l=%level", ",", "=", true, false), plainTextMsgLayout("%level | %msg"), true, false),
-                sender), appender -> {
-            appender.append(eventsToOrder);
-            appender.waitAllAppended();
-            assertEquals(
-                "dynamic labels, sort by time",
-                StringPayload.builder()
-                    .stream("[l, INFO]",
-                        "ts=100 INFO | Test message 3",
-                        "ts=105 INFO | Test message 1",
                         "ts=110 INFO | Test message 6")
                     .stream("[l, DEBUG]",
                         "ts=103 DEBUG | Test message 2")

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Generators.java
@@ -97,7 +97,6 @@ public class Generators {
         encoder.setStaticLabels(staticLabels);
         encoder.setLabel(labelCfg("test=" + testLabel + ",level=%level,service_name=my-app", ",", "=", true, false));
         encoder.setMessage(msgLayout);
-        encoder.setSortByTime(true);
         return encoder;
     }
 
@@ -129,7 +128,6 @@ public class Generators {
         return toStringEncoder(
             labelCfg("level=%level,app=my-app", ",", "=", true, false),
             plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
-            true,
             false);
     }
 
@@ -151,7 +149,6 @@ public class Generators {
             BiFunction<Integer, ByteBufferFactory, Writer> writerFactory,
             AbstractLoki4jEncoder.LabelCfg label,
             Layout<ILoggingEvent> messageLayout,
-            boolean sortByTime,
             boolean staticLabels) {
         var encoder = new AbstractLoki4jEncoder() {
             @Override
@@ -161,7 +158,6 @@ public class Generators {
         };
         encoder.setLabel(label);
         encoder.setMessage(messageLayout);
-        encoder.setSortByTime(sortByTime);
         encoder.setStaticLabels(staticLabels);
         return encoder;
     }
@@ -169,9 +165,8 @@ public class Generators {
     public static AbstractLoki4jEncoder toStringEncoder(
             AbstractLoki4jEncoder.LabelCfg label,
             Layout<ILoggingEvent> messageLayout,
-            boolean sortByTime,
             boolean staticLabels) {
-        return wrapToEncoder(Generators::stringWriter, label, messageLayout, sortByTime, staticLabels);
+        return wrapToEncoder(Generators::stringWriter, label, messageLayout, staticLabels);
     }
 
     public static AbstractLoki4jEncoder.LabelCfg labelCfg(

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/JsonLayoutTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/JsonLayoutTest.java
@@ -50,7 +50,6 @@ public class JsonLayoutTest {
         var encoder = toStringEncoder(
                 labelCfg("app=my-app", ",", "=", true, false),
                 jsonMsgLayout(),
-                false,
                 false
         );
         var sender = dummySender();

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/Loki4jAppenderTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/Loki4jAppenderTest.java
@@ -119,7 +119,6 @@ public class Loki4jAppenderTest {
                 },
                 labelCfg("level=%level,app=my-app", ",", "=", true, false),
                 plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
-                true,
                 false);
         var sender = dummySender();
         var appender = appender(4, 4000L, encoder, sender);

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/performance/reg_v151/StreamCachesTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/performance/reg_v151/StreamCachesTest.java
@@ -25,7 +25,6 @@ public class StreamCachesTest {
         var e = toStringEncoder(
             labelCfg("level=%level,app=my-app,date=%date{HH:mm:ss.SSS}", ",", "=", true, false),
             plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
-            false,
             false);
         e.setContext(new LoggerContext());
         e.getLabel().setStreamCache(streamCache);

--- a/loki-logback-appender/src/test/java/com/github/loki4j/logback/performance/reg_v160/StructuredMetadataTest.java
+++ b/loki-logback-appender/src/test/java/com/github/loki4j/logback/performance/reg_v160/StructuredMetadataTest.java
@@ -26,7 +26,6 @@ public class StructuredMetadataTest {
         var e = toStringEncoder(
             labelCfg,
             plainTextMsgLayout("l=%level c=%logger{20} t=%thread | %msg %ex{1}"),
-            true,
             false);
         var a = appender(1000, 60_000L, e, dummySender());
         a.setSendQueueMaxBytes(Long.MAX_VALUE);


### PR DESCRIPTION
As min supported Loki version was increased to 2.8.0, 'entry out of order' is no longer an issue.